### PR TITLE
feat: Adds GleanToolkit to expose tools as a group

### DIFF
--- a/langchain_glean/__init__.py
+++ b/langchain_glean/__init__.py
@@ -2,6 +2,7 @@ from importlib import metadata
 
 from langchain_glean.chat_models import ChatGlean
 from langchain_glean.retrievers import GleanPeopleProfileRetriever, GleanSearchRetriever
+from langchain_glean.toolkit import GleanToolkit
 from langchain_glean.tools import GleanChatTool, GleanPeopleProfileSearchTool, GleanSearchTool
 
 try:
@@ -18,5 +19,6 @@ __all__ = [
     "GleanSearchTool",
     "GleanPeopleProfileSearchTool",
     "GleanChatTool",
+    "GleanToolkit",
     "__version__",
 ]

--- a/langchain_glean/toolkit.py
+++ b/langchain_glean/toolkit.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import List
+
+from langchain_core.tools import BaseTool, BaseToolkit
+from pydantic import Field
+
+from langchain_glean.retrievers.people import GleanPeopleProfileRetriever
+from langchain_glean.retrievers.search import GleanSearchRetriever
+from langchain_glean.tools.chat import GleanChatTool
+from langchain_glean.tools.people_profile_search import (
+    GleanPeopleProfileSearchTool,
+)
+from langchain_glean.tools.search import GleanSearchTool
+
+
+class GleanToolkit(BaseToolkit):
+    """Aggregates all first-party Glean tools for easy agent injection."""
+
+    search_retriever: GleanSearchRetriever = Field(default_factory=GleanSearchRetriever, repr=False)
+    people_retriever: GleanPeopleProfileRetriever = Field(default_factory=GleanPeopleProfileRetriever, repr=False)
+
+    def get_tools(self) -> List[BaseTool]:
+        """Return instantiated Glean tools."""
+        return [
+            GleanChatTool(),
+            GleanPeopleProfileSearchTool(retriever=self.people_retriever),
+            GleanSearchTool(retriever=self.search_retriever),
+        ]

--- a/tests/unit_tests/test_glean_toolkit.py
+++ b/tests/unit_tests/test_glean_toolkit.py
@@ -1,0 +1,28 @@
+import os
+from unittest.mock import patch
+
+from langchain_glean.toolkit import GleanToolkit
+from langchain_glean.tools.chat import GleanChatTool
+from langchain_glean.tools.people_profile_search import GleanPeopleProfileSearchTool
+from langchain_glean.tools.search import GleanSearchTool
+
+
+class TestGleanToolkit:
+    """Verify that the toolkit returns the expected tools."""
+
+    def test_get_tools(self) -> None:
+        os.environ["GLEAN_INSTANCE"] = "test-glean"
+        os.environ["GLEAN_API_TOKEN"] = "test-token"
+        os.environ["GLEAN_ACT_AS"] = "test@example.com"
+
+        with patch("langchain_glean.retrievers.people.Glean"), patch("langchain_glean.retrievers.search.Glean"):
+            tk = GleanToolkit()
+            tools = tk.get_tools()
+
+        assert len(tools) == 3
+        assert any(isinstance(t, GleanChatTool) for t in tools)
+        assert any(isinstance(t, GleanPeopleProfileSearchTool) for t in tools)
+        assert any(isinstance(t, GleanSearchTool) for t in tools)
+
+        for var in ["GLEAN_INSTANCE", "GLEAN_API_TOKEN", "GLEAN_ACT_AS"]:
+            os.environ.pop(var, None)


### PR DESCRIPTION
# Summary

This pull request introduces a new `GleanToolkit` class to simplify the integration of Glean tools and adds corresponding unit tests. The most important changes include the implementation of the toolkit, updates to the module's exports, and the addition of tests to verify the toolkit's functionality.

### Addition of `GleanToolkit`:

* **New `GleanToolkit` class**: Introduced in `langchain_glean/toolkit.py`, this class aggregates Glean tools (`GleanChatTool`, `GleanPeopleProfileSearchTool`, and `GleanSearchTool`) and provides a `get_tools` method to return instantiated tools. It uses `Field` to initialize retrievers with default factories.

### Updates to module exports:

* **Exports update in `langchain_glean/__init__.py`**: Added `GleanToolkit` to the module's exports to make it accessible as part of the library's public API. [[1]](diffhunk://#diff-445f683ce73b8dd0d93bcb8ed6ab8d88291f98b7227ebe8c1363a8c49d4d7dcdR5) [[2]](diffhunk://#diff-445f683ce73b8dd0d93bcb8ed6ab8d88291f98b7227ebe8c1363a8c49d4d7dcdR22)

### Unit tests:

* **New test for `GleanToolkit`**: Added a unit test in `tests/unit_tests/test_glean_toolkit.py` to verify that the `get_tools` method of `GleanToolkit` correctly returns the expected tools (`GleanChatTool`, `GleanPeopleProfileSearchTool`, and `GleanSearchTool`). The test uses environment variable mocking and ensures cleanup after execution.