### PR TITLE
Use namespaced imports for usage with `glean-api-client@0.6`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ response = chat.invoke(ChatBasicRequest(
 #### Using the full Glean SDK request
 
 ```python
-from glean import models
+from glean.api_client import models
 from langchain_glean.chat_models import ChatGlean
 
 chat = ChatGlean()
@@ -146,7 +146,7 @@ results = retriever.invoke(SearchBasicRequest(
 #### Using the full Glean SDK request
 
 ```python
-from glean import models
+from glean.api_client import models
 from langchain_glean.retrievers import GleanSearchRetriever
 
 retriever = GleanSearchRetriever()
@@ -186,7 +186,7 @@ results = people.invoke(PeopleProfileBasicRequest(
 #### Using the full Glean SDK request
 
 ```python
-from glean import models
+from glean.api_client import models
 from langchain_glean.retrievers import GleanPeopleProfileRetriever
 
 people = GleanPeopleProfileRetriever()

--- a/langchain_glean/chat_models/agent_chat.py
+++ b/langchain_glean/chat_models/agent_chat.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional, cast
 
-from glean import Glean, errors, models
+from glean.api_client import Glean, errors, models
 from langchain_core.callbacks import AsyncCallbackManagerForLLMRun, CallbackManagerForLLMRun
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage

--- a/langchain_glean/chat_models/chat.py
+++ b/langchain_glean/chat_models/chat.py
@@ -1,6 +1,6 @@
 from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Union, cast
 
-from glean import Glean, errors, models  # noqa: F401
+from glean.api_client import Glean, errors, models  # noqa: F401
 from langchain_core.callbacks import (
     AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,

--- a/langchain_glean/retrievers/people.py
+++ b/langchain_glean/retrievers/people.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Union
 
-from glean import Glean  # noqa: F401
-from glean import errors, models
+from glean.api_client import Glean, errors, models
 from langchain_core.callbacks import (
     AsyncCallbackManagerForRetrieverRun,
     CallbackManagerForRetrieverRun,

--- a/langchain_glean/retrievers/search.py
+++ b/langchain_glean/retrievers/search.py
@@ -1,8 +1,7 @@
 # ruff: noqa: I001
 from typing import Any, Iterable, List, Optional, Union
 
-from glean import Glean  # noqa: F401
-from glean import errors, models
+from glean.api_client import Glean, errors, models
 from langchain_core.callbacks import (
     AsyncCallbackManagerForRetrieverRun,
     CallbackManagerForRetrieverRun,

--- a/langchain_glean/tools/get_agent_schema.py
+++ b/langchain_glean/tools/get_agent_schema.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from glean import Glean, errors
+from glean.api_client import Glean, errors
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field
 

--- a/langchain_glean/tools/list_agents.py
+++ b/langchain_glean/tools/list_agents.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from glean import Glean, errors
+from glean.api_client import Glean, errors
 from langchain_core.tools import BaseTool
 
 from langchain_glean._api_client_mixin import GleanAPIClientMixin

--- a/langchain_glean/tools/run_agent.py
+++ b/langchain_glean/tools/run_agent.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from glean import Glean, errors
+from glean.api_client import Glean, errors
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field
 

--- a/langchain_glean/tools/search.py
+++ b/langchain_glean/tools/search.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Union
 
-from glean import errors
+from glean.api_client import errors
 from langchain_core.tools import BaseTool
 from pydantic import Field
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.9,<4.0"
-dependencies = ["glean-api-client>=0.4.2", "langchain-core>=0.3.45"]
+dependencies = ["glean-api-client>=0.6,<0.7", "langchain-core>=0.3.45"]
 
 [project.optional-dependencies]
 dev = ["commitizen>=4.4.1"]

--- a/tests/integration_tests/test_glean_people_profile_retriever.py
+++ b/tests/integration_tests/test_glean_people_profile_retriever.py
@@ -3,7 +3,12 @@ import unittest
 from typing import List, Type
 
 from dotenv import load_dotenv
-from glean.models import FacetFilter, FacetFilterValue, ListEntitiesRequest, RelationType
+from glean.api_client.models import (
+    FacetFilter,
+    FacetFilterValue,
+    ListEntitiesRequest,
+    RelationType,
+)
 from langchain_core.documents import Document
 
 from langchain_glean.retrievers.people import GleanPeopleProfileRetriever, PeopleProfileBasicRequest

--- a/tests/integration_tests/test_glean_search_retriever.py
+++ b/tests/integration_tests/test_glean_search_retriever.py
@@ -3,7 +3,13 @@ import unittest
 from typing import List, Type
 
 from dotenv import load_dotenv
-from glean.models import FacetFilter, FacetFilterValue, RelationType, SearchRequest, SearchRequestOptions
+from glean.api_client.models import (
+    FacetFilter,
+    FacetFilterValue,
+    RelationType,
+    SearchRequest,
+    SearchRequestOptions,
+)
 from langchain_core.documents import Document
 
 from langchain_glean.retrievers import GleanSearchRetriever

--- a/tests/unit_tests/test_glean_agent_chat_model.py
+++ b/tests/unit_tests/test_glean_agent_chat_model.py
@@ -162,7 +162,7 @@ class TestGleanAgentChatModel:
 
     def test_generate_with_error(self):
         """Test error handling in _generate."""
-        from glean import errors
+        from glean.api_client import errors
 
         self.mock_glean.return_value.__enter__.return_value.client.agents.run.side_effect = errors.GleanError("Test error")
 
@@ -228,7 +228,7 @@ class TestGleanAgentChatModel:
     @pytest.mark.asyncio
     async def test_agenerate_with_error(self):
         """Test error handling in _agenerate."""
-        from glean import errors
+        from glean.api_client import errors
 
         # Override the run_async method to raise an error
         async def mock_run_async_error(*args, **kwargs):

--- a/tests/unit_tests/test_glean_get_agent_schema_tool.py
+++ b/tests/unit_tests/test_glean_get_agent_schema_tool.py
@@ -89,7 +89,7 @@ class TestGleanGetAgentSchemaTool:
 
     def test_run_with_glean_error(self) -> None:
         """Test _run when a GleanError occurs."""
-        from glean import errors
+        from glean.api_client import errors
 
         # Mock GleanError
         error = errors.GleanError("Test error")
@@ -148,7 +148,7 @@ class TestGleanGetAgentSchemaTool:
     @pytest.mark.asyncio
     async def test_arun_with_glean_error(self) -> None:
         """Test _arun when a GleanError occurs."""
-        from glean import errors
+        from glean.api_client import errors
 
         # Mock GleanError
         error = errors.GleanError("Test error")

--- a/tests/unit_tests/test_glean_list_agents_tool.py
+++ b/tests/unit_tests/test_glean_list_agents_tool.py
@@ -82,7 +82,7 @@ class TestGleanListAgentsTool:
 
     def test_run_with_glean_error(self) -> None:
         """Test _run when a GleanError occurs."""
-        from glean import errors
+        from glean.api_client import errors
 
         # Mock GleanError
         error = errors.GleanError("Test error")
@@ -139,7 +139,7 @@ class TestGleanListAgentsTool:
     @pytest.mark.asyncio
     async def test_arun_with_glean_error(self) -> None:
         """Test _arun when a GleanError occurs."""
-        from glean import errors
+        from glean.api_client import errors
 
         # Mock GleanError
         error = errors.GleanError("Test error")

--- a/tests/unit_tests/test_glean_people_profile_retriever.py
+++ b/tests/unit_tests/test_glean_people_profile_retriever.py
@@ -3,7 +3,12 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
-from glean.models import FacetFilter, FacetFilterValue, ListEntitiesRequest, RelationType
+from glean.api_client.models import (
+    FacetFilter,
+    FacetFilterValue,
+    ListEntitiesRequest,
+    RelationType,
+)
 from langchain_core.documents import Document
 
 from langchain_glean.retrievers.people import GleanPeopleProfileRetriever, PeopleProfileBasicRequest
@@ -227,7 +232,7 @@ class TestGleanPeopleProfileRetriever:
 
     def test_error_handling(self) -> None:
         """Test error handling when Glean API call fails."""
-        from glean import errors
+        from glean.api_client import errors
 
         # Simulate a GleanError
         self.mock_glean.return_value.__enter__.return_value.client.entities.list.side_effect = errors.GleanError("Test error")

--- a/tests/unit_tests/test_glean_run_agent_tool.py
+++ b/tests/unit_tests/test_glean_run_agent_tool.py
@@ -102,7 +102,7 @@ class TestGleanRunAgentTool:
 
     def test_run_with_glean_error(self) -> None:
         """Test _run when a GleanError occurs."""
-        from glean import errors
+        from glean.api_client import errors
 
         # Mock GleanError
         error = errors.GleanError("Test error")
@@ -181,7 +181,7 @@ class TestGleanRunAgentTool:
     @pytest.mark.asyncio
     async def test_arun_with_glean_error(self) -> None:
         """Test _arun when a GleanError occurs."""
-        from glean import errors
+        from glean.api_client import errors
 
         # Mock GleanError
         error = errors.GleanError("Test error")

--- a/tests/unit_tests/test_glean_search_retriever.py
+++ b/tests/unit_tests/test_glean_search_retriever.py
@@ -3,7 +3,13 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
-from glean.models import FacetFilter, FacetFilterValue, RelationType, SearchRequest, SearchRequestOptions
+from glean.api_client.models import (
+    FacetFilter,
+    FacetFilterValue,
+    RelationType,
+    SearchRequest,
+    SearchRequestOptions,
+)
 from langchain_core.documents import Document
 
 from langchain_glean.retrievers.search import GleanSearchRetriever

--- a/uv.lock
+++ b/uv.lock
@@ -253,15 +253,15 @@ wheels = [
 
 [[package]]
 name = "glean-api-client"
-version = "0.4.2"
+version = "0.6.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/cb/a74b3ec14cb5395f552afe3944a131dc6238d9925629f847fefabbbb7d11/glean_api_client-0.4.2.tar.gz", hash = "sha256:e7d9651f0add2ff4978caa537e66b6bf9ae5c343af3bab6b1f9cb963bd167019", size = 205841 }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/99/da764595c6c8a649b64eace71d7f75ff6fe610a65b7d26a82f8a339e75ef/glean_api_client-0.6.6.tar.gz", hash = "sha256:77f8292781caf1576119549ed5b8832108b21b97b5d399becf37b7a9a99af5a2", size = 219942 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/25/7c464d6d498f7590f114164c99ae4fd5fc6ef03f7494a519d7b6fbeaf5d2/glean_api_client-0.4.2-py3-none-any.whl", hash = "sha256:6243f8c0ac320716310181b7bb7eb6702b25bba1d6d66194790a0107df53b41e", size = 430620 },
+    { url = "https://files.pythonhosted.org/packages/4b/19/67756bb340354ede358fabff2d7793153a16f8ae20a1025e7ef5f0ba8e5f/glean_api_client-0.6.6-py3-none-any.whl", hash = "sha256:88caf5120fc25e00770739874ed3b6236fd6aa5866cd5c74e9d6258fbeefa32a", size = 430620 },
 ]
 
 [[package]]
@@ -418,7 +418,7 @@ typing = [
 requires-dist = [
     { name = "codespell", marker = "extra == 'codespell'", specifier = ">=2.2.6" },
     { name = "commitizen", marker = "extra == 'dev'", specifier = ">=4.4.1" },
-    { name = "glean-api-client", specifier = ">=0.4.2" },
+    { name = "glean-api-client", specifier = ">=0.6,<0.7" },
     { name = "langchain-core", specifier = ">=0.3.45" },
     { name = "langchain-tests", marker = "extra == 'test'", specifier = ">=0.3.5" },
     { name = "mypy", marker = "extra == 'typing'", specifier = ">=1.10" },


### PR DESCRIPTION
This pull request updates the imports across the codebase to use the new `glean.api_client` module instead of the old `glean` module. Additionally, it updates the `glean-api-client` dependency version in the `pyproject.toml` file and modifies tests to align with the updated imports. 

### Updates to Imports:

* Updated all occurrences of `glean` imports to use `glean.api_client` across multiple files, including `langchain_glean/chat_models/agent_chat.py`, `langchain_glean/retrievers/people.py`, and various tools and retrievers. [[1]](diffhunk://#diff-0294d414cabf83326481e47992a672a02e9545f73a2aefe805e4029ba90980b3L3-R3) [[2]](diffhunk://#diff-d0048f73ef028b565f766f76c22c70a6c1492cf339574a9cc2ea067c7eed2681L6-R6) [[3]](diffhunk://#diff-8a7c3f10539a833d9d00196443c9948ba82a20f33d72077ff471a94f5582ec46L3-R3) [[4]](diffhunk://#diff-73fa11ebcc31639728c486e5a7f198a317312a981c5099f7120bace6fce5268fL3-R3) [[5]](diffhunk://#diff-7571e8f4bbad5dbdcb0ee59837f608876752ec77c7823b42ffb8779a18d51c0dL3-R3) [[6]](diffhunk://#diff-166b51bff2259c359349fc55c2a54bb4c7f8362837423d7e47578c310d1202b1L3-R3)

* Updated imports in test files to use `glean.api_client.models` for classes such as `FacetFilter` and `RelationType`. [[1]](diffhunk://#diff-819526cb714b3ce4e68ac49e6420604e6617031be3a017a2cd8dccd5b2730e40L6-R11) [[2]](diffhunk://#diff-611eab1e40f477661cf94d227589585185651da5effda83a374a327eaf0edd06L6-R11) [[3]](diffhunk://#diff-482f06010bab3013ea61a4978e0f92ab37ab93d3c1309a9de2594cbcbb3e8962L6-R12)

### Dependency Version Update:

* Updated the `glean-api-client` dependency version in `pyproject.toml` to `>=0.6,<0.7` to ensure compatibility with the new module structure.

### Test Adjustments:

* Modified error handling in tests to import `errors` from `glean.api_client` instead of `glean`. This change affects multiple test files, such as `test_glean_agent_chat_model.py`, `test_glean_get_agent_schema_tool.py`, and others. [[1]](diffhunk://#diff-17367240ffb6179407bf5869ca9f17b1764384200a19bb9ec9f6e847a1ba80d9L165-R165) [[2]](diffhunk://#diff-620a71b881d3edf7c0e79547153859806e674acefbb6458a570b765030913410L92-R92) [[3]](diffhunk://#diff-0698d9f4ca0406aa7f3c7f7e3a0c8cb085a9a2d6858aa941ab8a8c9cef65f801L85-R85) [[4]](diffhunk://#diff-cd9f700ea28f5fbe9c2379fe8d4d1ee1ef40b5706d37eb380f888522b9f9f87dL105-R105)