### PR TITLE
fix: Ensure act_as and GLEAN_ACT_AS are propagated

### DIFF
--- a/langchain_glean/_api_client_mixin.py
+++ b/langchain_glean/_api_client_mixin.py
@@ -25,3 +25,7 @@ class GleanAPIClientMixin:  # noqa: D401
         values["api_token"] = get_from_dict_or_env(values, "api_token", "GLEAN_API_TOKEN")
         values["act_as"] = get_from_dict_or_env(values, "act_as", "GLEAN_ACT_AS", default="")
         return values
+
+    def _http_headers(self) -> Optional[Dict[str, str]]:
+        """Return HTTP headers for impersonation if ``act_as`` is set."""
+        return {"X-Glean-ActAs": str(self.act_as)} if self.act_as else None

--- a/langchain_glean/chat_models/chat.py
+++ b/langchain_glean/chat_models/chat.py
@@ -268,6 +268,7 @@ class ChatGlean(GleanAPIClientMixin, BaseChatModel):
 
         try:
             with Glean(api_token=self.api_token, instance=self.instance) as g:
+                headers = self._http_headers()
                 response = g.client.chat.create(
                     messages=params.messages,
                     save_chat=params.save_chat,
@@ -277,6 +278,7 @@ class ChatGlean(GleanAPIClientMixin, BaseChatModel):
                     exclusions=params.exclusions,
                     timeout_millis=params.timeout_millis if hasattr(params, "timeout_millis") else None,
                     application_id=params.application_id if hasattr(params, "application_id") else None,
+                    http_headers=headers,
                 )
 
         except errors.GleanError as client_err:
@@ -359,6 +361,7 @@ class ChatGlean(GleanAPIClientMixin, BaseChatModel):
 
         try:
             with Glean(api_token=self.api_token, instance=self.instance) as g:
+                headers = self._http_headers()
                 response = await g.client.chat.create_async(
                     messages=params.messages,
                     save_chat=params.save_chat,
@@ -368,6 +371,7 @@ class ChatGlean(GleanAPIClientMixin, BaseChatModel):
                     exclusions=params.exclusions,
                     timeout_millis=params.timeout_millis if hasattr(params, "timeout_millis") else None,
                     application_id=params.application_id if hasattr(params, "application_id") else None,
+                    http_headers=headers,
                 )
 
         except errors.GleanError as client_err:
@@ -452,6 +456,7 @@ class ChatGlean(GleanAPIClientMixin, BaseChatModel):
 
         try:
             with Glean(api_token=self.api_token, instance=self.instance) as g:
+                headers = self._http_headers()
                 response_stream = g.client.chat.create_stream(
                     messages=params.messages,
                     save_chat=params.save_chat,
@@ -462,6 +467,7 @@ class ChatGlean(GleanAPIClientMixin, BaseChatModel):
                     timeout_millis=params.timeout_millis if hasattr(params, "timeout_millis") else None,
                     application_id=params.application_id if hasattr(params, "application_id") else None,
                     stream=True,
+                    http_headers=headers,
                 )
 
             for line in response_stream.splitlines():
@@ -543,6 +549,7 @@ class ChatGlean(GleanAPIClientMixin, BaseChatModel):
 
         try:
             with Glean(api_token=self.api_token, instance=self.instance) as g:
+                headers = self._http_headers()
                 response_stream = await g.client.chat.create_stream_async(
                     messages=params.messages,
                     save_chat=params.save_chat,
@@ -553,6 +560,7 @@ class ChatGlean(GleanAPIClientMixin, BaseChatModel):
                     timeout_millis=params.timeout_millis if hasattr(params, "timeout_millis") else None,
                     application_id=params.application_id if hasattr(params, "application_id") else None,
                     stream=True,
+                    http_headers=headers,
                 )
 
             for line in response_stream.splitlines():

--- a/langchain_glean/retrievers/search.py
+++ b/langchain_glean/retrievers/search.py
@@ -130,7 +130,8 @@ class GleanSearchRetriever(GleanAPIClientMixin, BaseRetriever):
 
             try:
                 with Glean(api_token=self.api_token, instance=self.instance) as g:
-                    response = g.client.search.query(request=search_request)
+                    headers = self._http_headers()
+                    response = g.client.search.query(request=search_request, http_headers=headers)
 
             except errors.GleanError as client_err:
                 run_manager.on_retriever_error(Exception(f"Glean client error: {str(client_err)}"))
@@ -178,7 +179,8 @@ class GleanSearchRetriever(GleanAPIClientMixin, BaseRetriever):
 
             try:
                 with Glean(api_token=self.api_token, instance=self.instance) as g:
-                    response = await g.client.search.query_async(request=search_request)
+                    headers = self._http_headers()
+                    response = await g.client.search.query_async(request=search_request, http_headers=headers)
 
             except errors.GleanError as client_err:
                 await run_manager.on_retriever_error(Exception(f"Glean client error: {str(client_err)}"))

--- a/tests/unit_tests/test_glean_search_retriever.py
+++ b/tests/unit_tests/test_glean_search_retriever.py
@@ -161,7 +161,10 @@ class TestGleanSearchRetriever:
             assert kwargs["max_snippet_size"] == 100
 
             # Verify that query was called with the mocked search request
-            self.mock_glean.return_value.__enter__.return_value.client.search.query.assert_called_once_with(request=search_request_mock)
+            self.mock_glean.return_value.__enter__.return_value.client.search.query.assert_called_once_with(
+                request=search_request_mock,
+                http_headers={"X-Glean-ActAs": "test@example.com"},
+            )
 
     def test_build_document(self) -> None:
         """Test the _build_document method."""
@@ -199,7 +202,10 @@ class TestGleanSearchRetriever:
         docs = self.retriever.invoke(search_request)
 
         # Verify the search was called with our request object
-        self.mock_glean.return_value.__enter__.return_value.client.search.query.assert_called_once_with(request=search_request)
+        self.mock_glean.return_value.__enter__.return_value.client.search.query.assert_called_once_with(
+            request=search_request,
+            http_headers={"X-Glean-ActAs": "test@example.com"},
+        )
 
         # Verify we got documents back
         assert len(docs) == 1


### PR DESCRIPTION
Prior to this, we had code that would read `act_as` (model instance property) and `GLEAN_ACT_AS` (environment variable), but it was not passed through to the underlying API client invocations.

Fix #18 