### PR TITLE
Fix agent offline error

### DIFF
--- a/langchain_glean/chat_models/agent_chat.py
+++ b/langchain_glean/chat_models/agent_chat.py
@@ -41,7 +41,7 @@ class ChatGleanAgent(GleanAPIClientMixin, BaseChatModel):
 
         try:
             with Glean(api_token=self.api_token, instance=self.instance) as g:
-                response = g.client.agents.run(agent_id=self.agent_id, fields=fields, stream=False)
+                response = g.client.agents.run(agent_id=self.agent_id, input_=fields)
         except errors.GleanError as e:
             raise ValueError(f"Glean client error: {e}") from e
         except Exception:
@@ -98,7 +98,7 @@ class ChatGleanAgent(GleanAPIClientMixin, BaseChatModel):
 
         try:
             with Glean(api_token=self.api_token, instance=self.instance) as g:
-                response = await g.client.agents.run_async(agent_id=self.agent_id, fields=fields, stream=False)
+                response = await g.client.agents.run_async(agent_id=self.agent_id, input_=fields)
         except errors.GleanError as e:
             raise ValueError(f"Glean client error: {e}") from e
         except Exception:

--- a/langchain_glean/chat_models/agent_chat.py
+++ b/langchain_glean/chat_models/agent_chat.py
@@ -41,7 +41,7 @@ class ChatGleanAgent(GleanAPIClientMixin, BaseChatModel):
 
         try:
             with Glean(api_token=self.api_token, instance=self.instance) as g:
-                response = g.client.agents.run(agent_id=self.agent_id, input_=fields)
+                response = g.client.agents.run(agent_id=self.agent_id, input=fields)
         except errors.GleanError as e:
             raise ValueError(f"Glean client error: {e}") from e
         except Exception:
@@ -98,7 +98,7 @@ class ChatGleanAgent(GleanAPIClientMixin, BaseChatModel):
 
         try:
             with Glean(api_token=self.api_token, instance=self.instance) as g:
-                response = await g.client.agents.run_async(agent_id=self.agent_id, input_=fields)
+                response = await g.client.agents.run_async(agent_id=self.agent_id, input=fields)
         except errors.GleanError as e:
             raise ValueError(f"Glean client error: {e}") from e
         except Exception:

--- a/langchain_glean/tools/run_agent.py
+++ b/langchain_glean/tools/run_agent.py
@@ -10,7 +10,6 @@ from langchain_glean._api_client_mixin import GleanAPIClientMixin
 class RunAgentArgs(BaseModel):
     agent_id: str = Field(..., description="ID of the agent to run")
     fields: Dict[str, str] = Field(default_factory=dict, description="Input fields mapping for the agent")
-    stream: Optional[bool] = Field(default=None, description="Whether to stream the response")
 
 
 class GleanRunAgentTool(GleanAPIClientMixin, BaseTool):
@@ -22,10 +21,10 @@ class GleanRunAgentTool(GleanAPIClientMixin, BaseTool):
 
     args_schema: type = RunAgentArgs
 
-    def _run(self, agent_id: str, fields: Dict[str, str], stream: Optional[bool] = None, **kwargs: Any) -> str:  # noqa: D401
+    def _run(self, agent_id: str, fields: Dict[str, str], **kwargs: Any) -> str:  # noqa: D401
         try:
             with Glean(api_token=self.api_token, instance=self.instance) as g:
-                response = g.client.agents.run(agent_id=agent_id, fields=fields, stream=stream)
+                response = g.client.agents.run(agent_id=agent_id, input_=fields)
 
             if hasattr(response, "model_dump_json"):
                 return response.model_dump_json(indent=2)
@@ -39,10 +38,10 @@ class GleanRunAgentTool(GleanAPIClientMixin, BaseTool):
         except Exception as e:  # noqa: BLE001
             return f"Error running agent: {e}"
 
-    async def _arun(self, agent_id: str, fields: Dict[str, str], stream: Optional[bool] = None, **kwargs: Any) -> str:  # noqa: D401
+    async def _arun(self, agent_id: str, fields: Dict[str, str], **kwargs: Any) -> str:  # noqa: D401
         try:
             with Glean(api_token=self.api_token, instance=self.instance) as g:
-                response = await g.client.agents.run_async(agent_id=agent_id, fields=fields, stream=stream)
+                response = await g.client.agents.run_async(agent_id=agent_id, input_=fields)
 
             if hasattr(response, "model_dump_json"):
                 return response.model_dump_json(indent=2)

--- a/langchain_glean/tools/run_agent.py
+++ b/langchain_glean/tools/run_agent.py
@@ -24,7 +24,7 @@ class GleanRunAgentTool(GleanAPIClientMixin, BaseTool):
     def _run(self, agent_id: str, fields: Dict[str, str], **kwargs: Any) -> str:  # noqa: D401
         try:
             with Glean(api_token=self.api_token, instance=self.instance) as g:
-                response = g.client.agents.run(agent_id=agent_id, input_=fields)
+                response = g.client.agents.run(agent_id=agent_id, input=fields)
 
             if hasattr(response, "model_dump_json"):
                 return response.model_dump_json(indent=2)
@@ -41,7 +41,7 @@ class GleanRunAgentTool(GleanAPIClientMixin, BaseTool):
     async def _arun(self, agent_id: str, fields: Dict[str, str], **kwargs: Any) -> str:  # noqa: D401
         try:
             with Glean(api_token=self.api_token, instance=self.instance) as g:
-                response = await g.client.agents.run_async(agent_id=agent_id, input_=fields)
+                response = await g.client.agents.run_async(agent_id=agent_id, input=fields)
 
             if hasattr(response, "model_dump_json"):
                 return response.model_dump_json(indent=2)

--- a/tests/integration_tests/test_glean_run_agent_tool.py
+++ b/tests/integration_tests/test_glean_run_agent_tool.py
@@ -62,17 +62,6 @@ class TestGleanRunAgentToolIntegration(unittest.TestCase):
             self.assertIsInstance(result, str)
             self.assertTrue(len(result) > 0)
 
-    def test_run_with_streaming(self) -> None:
-        """Test running the tool with streaming enabled."""
-        # Basic fields for the agent
-        fields = {"input": "What can this agent do?"}
-
-        # Run the tool with streaming enabled
-        result = self.tool.run(agent_id=self.agent_id, fields=fields, stream=True)
-
-        # Verify the result
-        self.assertIsInstance(result, str)
-        self.assertTrue(len(result) > 0)
 
     async def test_arun_with_basic_input(self) -> None:
         """Test async running the tool with basic input."""
@@ -107,14 +96,3 @@ class TestGleanRunAgentToolIntegration(unittest.TestCase):
             self.assertIsInstance(result, str)
             self.assertTrue(len(result) > 0)
 
-    async def test_arun_with_streaming(self) -> None:
-        """Test async running the tool with streaming enabled."""
-        # Basic fields for the agent
-        fields = {"input": "What can this agent do?"}
-
-        # Run the tool asynchronously with streaming enabled
-        result = await self.tool.arun(agent_id=self.agent_id, fields=fields, stream=True)
-
-        # Verify the result
-        self.assertIsInstance(result, str)
-        self.assertTrue(len(result) > 0)


### PR DESCRIPTION
Root Cause
The error was caused by a TypeError in the ChatGleanAgent._generate() method. The code was trying to pass a fields parameter to the Glean API's Agents.run() method, but the correct parameter name is input_.
Issues Fixed
In langchain_glean/chat_models/agent_chat.py:
Changed g.client.agents.run(agent_id=self.agent_id, fields=fields, stream=False) to g.client.agents.run(agent_id=self.agent_id, input_=fields)
Changed g.client.agents.run_async(agent_id=self.agent_id, fields=fields, stream=False) to g.client.agents.run_async(agent_id=self.agent_id, input_=fields)
In langchain_glean/tools/run_agent.py:
Fixed the same parameter issue in the GleanRunAgentTool
Removed the unsupported stream parameter from the API calls
Updated the RunAgentArgs model to remove the stream field
Updated method signatures to remove the stream parameter
In tests/integration_tests/test_glean_run_agent_tool.py:
Removed tests that were using the unsupported stream parameter