### PR TITLE
test: add unit tests for GleanAPIClientMixin and GleanSearchTool

### DIFF
--- a/tests/unit_tests/test_api_client_mixin.py
+++ b/tests/unit_tests/test_api_client_mixin.py
@@ -1,0 +1,132 @@
+import os
+from typing import Optional
+
+import pytest
+from pydantic import BaseModel, Field
+
+from langchain_glean._api_client_mixin import GleanAPIClientMixin
+
+
+class _MixinTestModel(GleanAPIClientMixin, BaseModel):
+    """Minimal concrete model for testing GleanAPIClientMixin."""
+
+    pass
+
+
+class TestGleanAPIClientMixin:
+    """Test the GleanAPIClientMixin class."""
+
+    @pytest.fixture(autouse=True)
+    def setup_method(self):
+        """Set up the test environment."""
+        # Ensure env vars are clean before each test
+        for var in ["GLEAN_INSTANCE", "GLEAN_API_TOKEN", "GLEAN_ACT_AS"]:
+            os.environ.pop(var, None)
+
+        yield
+
+        # Clean up after tests
+        for var in ["GLEAN_INSTANCE", "GLEAN_API_TOKEN", "GLEAN_ACT_AS"]:
+            os.environ.pop(var, None)
+
+    # ===== ENVIRONMENT VARIABLE RESOLUTION =====
+
+    def test_resolve_from_env_vars(self) -> None:
+        """Test that fields are resolved from environment variables."""
+        os.environ["GLEAN_INSTANCE"] = "test-instance"
+        os.environ["GLEAN_API_TOKEN"] = "test-token"
+        os.environ["GLEAN_ACT_AS"] = "user@example.com"
+
+        model = _MixinTestModel()
+
+        assert model.instance == "test-instance"
+        assert model.api_token == "test-token"
+        assert model.act_as == "user@example.com"
+
+    def test_resolve_from_constructor_args(self) -> None:
+        """Test that constructor arguments take precedence over env vars."""
+        os.environ["GLEAN_INSTANCE"] = "env-instance"
+        os.environ["GLEAN_API_TOKEN"] = "env-token"
+
+        model = _MixinTestModel(instance="arg-instance", api_token="arg-token")
+
+        assert model.instance == "arg-instance"
+        assert model.api_token == "arg-token"
+
+    def test_constructor_args_override_env_vars(self) -> None:
+        """Test that constructor args override all env vars including act_as."""
+        os.environ["GLEAN_INSTANCE"] = "env-instance"
+        os.environ["GLEAN_API_TOKEN"] = "env-token"
+        os.environ["GLEAN_ACT_AS"] = "env-user@example.com"
+
+        model = _MixinTestModel(
+            instance="arg-instance",
+            api_token="arg-token",
+            act_as="arg-user@example.com",
+        )
+
+        assert model.instance == "arg-instance"
+        assert model.api_token == "arg-token"
+        assert model.act_as == "arg-user@example.com"
+
+    def test_missing_instance_raises_error(self) -> None:
+        """Test that missing GLEAN_INSTANCE raises ValueError."""
+        os.environ["GLEAN_API_TOKEN"] = "test-token"
+
+        with pytest.raises(ValueError):
+            _MixinTestModel()
+
+    def test_missing_api_token_raises_error(self) -> None:
+        """Test that missing GLEAN_API_TOKEN raises ValueError."""
+        os.environ["GLEAN_INSTANCE"] = "test-instance"
+
+        with pytest.raises(ValueError):
+            _MixinTestModel()
+
+    def test_missing_both_required_raises_error(self) -> None:
+        """Test that missing both required fields raises ValueError."""
+        with pytest.raises(ValueError):
+            _MixinTestModel()
+
+    def test_act_as_defaults_to_empty_string(self) -> None:
+        """Test that act_as defaults to empty string when not provided."""
+        os.environ["GLEAN_INSTANCE"] = "test-instance"
+        os.environ["GLEAN_API_TOKEN"] = "test-token"
+
+        model = _MixinTestModel()
+
+        assert model.act_as == ""
+
+    # ===== HTTP HEADERS =====
+
+    def test_http_headers_with_act_as(self) -> None:
+        """Test _http_headers returns ActAs header when act_as is set."""
+        os.environ["GLEAN_INSTANCE"] = "test-instance"
+        os.environ["GLEAN_API_TOKEN"] = "test-token"
+        os.environ["GLEAN_ACT_AS"] = "user@example.com"
+
+        model = _MixinTestModel()
+        headers = model._http_headers()
+
+        assert headers == {"X-Glean-ActAs": "user@example.com"}
+
+    def test_http_headers_without_act_as(self) -> None:
+        """Test _http_headers returns None when act_as is not set."""
+        os.environ["GLEAN_INSTANCE"] = "test-instance"
+        os.environ["GLEAN_API_TOKEN"] = "test-token"
+
+        model = _MixinTestModel()
+        headers = model._http_headers()
+
+        assert headers is None
+
+    def test_http_headers_with_empty_act_as(self) -> None:
+        """Test _http_headers returns None when act_as is empty string."""
+        os.environ["GLEAN_INSTANCE"] = "test-instance"
+        os.environ["GLEAN_API_TOKEN"] = "test-token"
+        os.environ["GLEAN_ACT_AS"] = ""
+
+        model = _MixinTestModel()
+        headers = model._http_headers()
+
+        assert headers is None

--- a/tests/unit_tests/test_glean_search_tool.py
+++ b/tests/unit_tests/test_glean_search_tool.py
@@ -1,0 +1,210 @@
+from unittest.mock import MagicMock
+
+import pytest
+from glean.api_client import errors
+from langchain_core.documents import Document
+
+from langchain_glean.retrievers import GleanSearchRetriever
+from langchain_glean.retrievers.search import SearchBasicRequest
+from langchain_glean.tools.search import GleanSearchTool
+
+
+class TestGleanSearchTool:
+    """Test the GleanSearchTool class."""
+
+    @pytest.fixture(autouse=True)
+    def setup_method(self):
+        """Set up the test environment."""
+        # Create mock retriever
+        self.mock_retriever = MagicMock(spec=GleanSearchRetriever)
+
+        # Set up sample documents for retriever responses
+        self.sample_doc1 = Document(
+            page_content="This is the first document content.",
+            metadata={
+                "title": "First Document",
+                "url": "https://example.com/doc1",
+                "datasource": "confluence",
+            },
+        )
+
+        self.sample_doc2 = Document(
+            page_content="This is the second document content.",
+            metadata={
+                "title": "Second Document",
+                "url": "https://example.com/doc2",
+                "datasource": "slack",
+            },
+        )
+
+        # Set up mock responses
+        self.mock_retriever.invoke.return_value = [self.sample_doc1, self.sample_doc2]
+        self.mock_retriever.ainvoke.return_value = [self.sample_doc1, self.sample_doc2]
+
+        # Initialize the tool with the mock retriever
+        self.tool = GleanSearchTool(retriever=self.mock_retriever)
+
+        yield
+
+    def test_init(self) -> None:
+        """Test the initialization of the tool."""
+        assert self.tool.name == "glean_search"
+        assert "Search for information in Glean" in self.tool.description
+        assert self.tool.retriever == self.mock_retriever
+        assert self.tool.args_schema == SearchBasicRequest
+        assert not self.tool.return_direct
+
+    # ===== SYNC _run TESTS =====
+
+    def test_run_with_string_query(self) -> None:
+        """Test _run with a plain string query."""
+        result = self.tool._run("test query")
+
+        self.mock_retriever.invoke.assert_called_once_with("test query")
+
+        assert "Result 1: First Document (confluence)" in result
+        assert "URL: https://example.com/doc1" in result
+        assert "Content: This is the first document content." in result
+        assert "Result 2: Second Document (slack)" in result
+        assert "URL: https://example.com/doc2" in result
+        assert "Content: This is the second document content." in result
+
+    def test_run_with_search_basic_request(self) -> None:
+        """Test _run with a SearchBasicRequest object."""
+        request = SearchBasicRequest(query="typed query")
+
+        result = self.tool._run(request)
+
+        self.mock_retriever.invoke.assert_called_once_with(request)
+
+        assert "Result 1: First Document (confluence)" in result
+
+    def test_run_with_dict_query(self) -> None:
+        """Test _run with a dictionary input (pops 'query' key)."""
+        result = self.tool._run({"query": "dict query", "extra_param": "value"})
+
+        self.mock_retriever.invoke.assert_called_once_with("dict query", extra_param="value")
+
+        assert "Result 1: First Document (confluence)" in result
+
+    def test_run_with_dict_missing_query_key(self) -> None:
+        """Test _run with a dict that has no 'query' key defaults to empty string."""
+        result = self.tool._run({"extra_param": "value"})
+
+        self.mock_retriever.invoke.assert_called_once_with("", extra_param="value")
+
+        assert "Result 1: First Document (confluence)" in result
+
+    def test_run_with_no_results(self) -> None:
+        """Test _run when no results are returned."""
+        self.mock_retriever.invoke.return_value = []
+
+        result = self.tool._run("no results query")
+
+        assert result == "No results found."
+
+    def test_run_with_missing_metadata(self) -> None:
+        """Test _run handles documents with missing metadata fields."""
+        doc_no_metadata = Document(
+            page_content="Content with no metadata.",
+            metadata={},
+        )
+        self.mock_retriever.invoke.return_value = [doc_no_metadata]
+
+        result = self.tool._run("sparse query")
+
+        assert "Result 1: Untitled (Unknown Source)" in result
+        assert "URL: No URL" in result
+        assert "Content: Content with no metadata." in result
+
+    def test_run_with_glean_error(self) -> None:
+        """Test _run when a GleanError occurs."""
+        mock_response = MagicMock()
+        mock_response.text = "Raw error response"
+        error = errors.GleanError("Test error", raw_response=mock_response)
+        self.mock_retriever.invoke.side_effect = error
+
+        result = self.tool._run("error query")
+
+        assert "Glean API error" in result
+        assert "Test error" in result
+
+    def test_run_with_glean_error_no_raw_response(self) -> None:
+        """Test _run when a GleanError occurs with empty raw_response."""
+        mock_response = MagicMock()
+        mock_response.text = ""
+        error = errors.GleanError("Test error", raw_response=mock_response)
+        # Remove raw_response so hasattr check returns False
+        error.raw_response = None
+        self.mock_retriever.invoke.side_effect = error
+
+        result = self.tool._run("error query")
+
+        assert "Glean API error: Test error" in result
+
+    def test_run_with_generic_exception(self) -> None:
+        """Test _run when a generic exception occurs."""
+        self.mock_retriever.invoke.side_effect = Exception("Generic error")
+
+        result = self.tool._run("error query")
+
+        assert "Error running Glean search: Generic error" in result
+
+    # ===== ASYNC _arun TESTS =====
+
+    async def test_arun_with_string_query(self) -> None:
+        """Test _arun with a plain string query."""
+        result = await self.tool._arun("test query")
+
+        self.mock_retriever.ainvoke.assert_called_once_with("test query")
+
+        assert "Result 1: First Document (confluence)" in result
+        assert "URL: https://example.com/doc1" in result
+        assert "Content: This is the first document content." in result
+        assert "Result 2: Second Document (slack)" in result
+
+    async def test_arun_with_search_basic_request(self) -> None:
+        """Test _arun with a SearchBasicRequest object."""
+        request = SearchBasicRequest(query="typed query")
+
+        result = await self.tool._arun(request)
+
+        self.mock_retriever.ainvoke.assert_called_once_with(request)
+
+        assert "Result 1: First Document (confluence)" in result
+
+    async def test_arun_with_dict_query(self) -> None:
+        """Test _arun with a dictionary input."""
+        result = await self.tool._arun({"query": "dict query", "extra_param": "value"})
+
+        self.mock_retriever.ainvoke.assert_called_once_with("dict query", extra_param="value")
+
+        assert "Result 1: First Document (confluence)" in result
+
+    async def test_arun_with_no_results(self) -> None:
+        """Test _arun when no results are returned."""
+        self.mock_retriever.ainvoke.return_value = []
+
+        result = await self.tool._arun("no results query")
+
+        assert result == "No results found."
+
+    async def test_arun_with_glean_error(self) -> None:
+        """Test _arun when a GleanError occurs."""
+        mock_response = MagicMock()
+        mock_response.text = "Raw error response"
+        error = errors.GleanError("Test error", raw_response=mock_response)
+        self.mock_retriever.ainvoke.side_effect = error
+
+        result = await self.tool._arun("error query")
+
+        assert "Glean API error" in result
+        assert "Test error" in result
+
+    async def test_arun_with_generic_exception(self) -> None:
+        """Test _arun when a generic exception occurs."""
+        self.mock_retriever.ainvoke.side_effect = Exception("Generic error")
+
+        result = await self.tool._arun("error query")
+
+        assert "Error running Glean search: Generic error" in result


### PR DESCRIPTION
## Description

Add unit tests for the two source files that had no dedicated test coverage:

- **`GleanAPIClientMixin`** (`_api_client_mixin.py`) — the shared auth mixin used by all major components. Tests cover environment variable resolution, constructor argument overrides, missing required fields raising `ValueError`, `act_as` default behavior, and `_http_headers()` returning the `X-Glean-ActAs` header or `None`.
- **`GleanSearchTool`** (`tools/search.py`) — the LangChain tool wrapper for search. Tests cover `_run`/`_arun` with string queries, `SearchBasicRequest` objects, dict inputs (with and without `query` key), empty results, missing metadata defaults, `GleanError` handling, and generic exception handling.

26 new tests total. All existing tests remain unaffected.

## Testing

- All 26 new tests pass: `pytest tests/unit_tests/test_glean_search_tool.py tests/unit_tests/test_api_client_mixin.py -v`
- Full sync unit test suite passes with `--disable-socket` (78 passed)

___
🤖 *Generated by Glean Code Writer*
📝 Chat link - https://app.glean.com/chat/b7a64f1b2d49429389f04ac6d6dd9bb2