### PR TITLE
test: add missing unit tests for GleanSearchTool, GleanToolkit, and GleanAPIClientMixin

### DIFF
--- a/tests/unit_tests/test_api_client_mixin.py
+++ b/tests/unit_tests/test_api_client_mixin.py
@@ -1,0 +1,152 @@
+import os
+from unittest.mock import patch
+
+import pytest
+
+from langchain_glean._api_client_mixin import GleanAPIClientMixin
+
+
+class TestGleanAPIClientMixin:
+    """Test the GleanAPIClientMixin shared auth and client configuration.
+
+    Uses GleanSearchRetriever as a concrete class that inherits the mixin,
+    since the mixin is designed to be used via multiple inheritance with
+    Pydantic models (BaseRetriever, BaseChatModel, BaseTool).
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_method(self):
+        """Clean environment before and after each test."""
+        for var in ["GLEAN_INSTANCE", "GLEAN_API_TOKEN", "GLEAN_ACT_AS"]:
+            os.environ.pop(var, None)
+
+        yield
+
+        for var in ["GLEAN_INSTANCE", "GLEAN_API_TOKEN", "GLEAN_ACT_AS"]:
+            os.environ.pop(var, None)
+
+    def _create_retriever(self, **kwargs):
+        """Helper to create a GleanSearchRetriever (concrete mixin user)."""
+        from langchain_glean.retrievers.search import GleanSearchRetriever
+
+        with patch("langchain_glean.retrievers.search.Glean"):
+            return GleanSearchRetriever(**kwargs)
+
+    def test_resolve_from_env_vars(self) -> None:
+        """Test that instance and api_token are resolved from env vars."""
+        os.environ["GLEAN_INSTANCE"] = "env-instance"
+        os.environ["GLEAN_API_TOKEN"] = "env-token"
+
+        retriever = self._create_retriever()
+
+        assert retriever.instance == "env-instance"
+        assert retriever.api_token == "env-token"
+
+    def test_resolve_from_constructor_args(self) -> None:
+        """Test that constructor args take precedence over env vars."""
+        os.environ["GLEAN_INSTANCE"] = "env-instance"
+        os.environ["GLEAN_API_TOKEN"] = "env-token"
+
+        retriever = self._create_retriever(instance="arg-instance", api_token="arg-token")
+
+        assert retriever.instance == "arg-instance"
+        assert retriever.api_token == "arg-token"
+
+    def test_missing_instance_raises(self) -> None:
+        """Test that missing GLEAN_INSTANCE raises ValueError."""
+        os.environ["GLEAN_API_TOKEN"] = "test-token"
+
+        with pytest.raises(ValueError):
+            self._create_retriever()
+
+    def test_missing_api_token_raises(self) -> None:
+        """Test that missing GLEAN_API_TOKEN raises ValueError."""
+        os.environ["GLEAN_INSTANCE"] = "test-instance"
+
+        with pytest.raises(ValueError):
+            self._create_retriever()
+
+    def test_act_as_from_env(self) -> None:
+        """Test that act_as is resolved from GLEAN_ACT_AS env var."""
+        os.environ["GLEAN_INSTANCE"] = "test-instance"
+        os.environ["GLEAN_API_TOKEN"] = "test-token"
+        os.environ["GLEAN_ACT_AS"] = "user@example.com"
+
+        retriever = self._create_retriever()
+
+        assert retriever.act_as == "user@example.com"
+
+    def test_act_as_from_constructor(self) -> None:
+        """Test that act_as can be provided via constructor."""
+        os.environ["GLEAN_INSTANCE"] = "test-instance"
+        os.environ["GLEAN_API_TOKEN"] = "test-token"
+
+        retriever = self._create_retriever(act_as="admin@example.com")
+
+        assert retriever.act_as == "admin@example.com"
+
+    def test_act_as_defaults_to_empty(self) -> None:
+        """Test that act_as defaults to empty string when not set."""
+        os.environ["GLEAN_INSTANCE"] = "test-instance"
+        os.environ["GLEAN_API_TOKEN"] = "test-token"
+
+        retriever = self._create_retriever()
+
+        assert retriever.act_as == ""
+
+    def test_http_headers_with_act_as(self) -> None:
+        """Test that _http_headers returns impersonation headers when act_as is set."""
+        os.environ["GLEAN_INSTANCE"] = "test-instance"
+        os.environ["GLEAN_API_TOKEN"] = "test-token"
+
+        retriever = self._create_retriever(act_as="user@example.com")
+        headers = retriever._http_headers()
+
+        assert headers == {"X-Glean-ActAs": "user@example.com"}
+
+    def test_http_headers_without_act_as(self) -> None:
+        """Test that _http_headers returns None when act_as is not set."""
+        os.environ["GLEAN_INSTANCE"] = "test-instance"
+        os.environ["GLEAN_API_TOKEN"] = "test-token"
+
+        retriever = self._create_retriever()
+        headers = retriever._http_headers()
+
+        assert headers is None
+
+    def test_constructor_args_override_env(self) -> None:
+        """Test that constructor args override environment variables for all fields."""
+        os.environ["GLEAN_INSTANCE"] = "env-instance"
+        os.environ["GLEAN_API_TOKEN"] = "env-token"
+        os.environ["GLEAN_ACT_AS"] = "env-user@example.com"
+
+        retriever = self._create_retriever(
+            instance="arg-instance",
+            api_token="arg-token",
+            act_as="arg-user@example.com",
+        )
+
+        assert retriever.instance == "arg-instance"
+        assert retriever.api_token == "arg-token"
+        assert retriever.act_as == "arg-user@example.com"
+
+    def test_mixin_works_with_multiple_concrete_classes(self) -> None:
+        """Test that the mixin works across different concrete classes."""
+        os.environ["GLEAN_INSTANCE"] = "test-instance"
+        os.environ["GLEAN_API_TOKEN"] = "test-token"
+
+        with patch("langchain_glean.retrievers.search.Glean"):
+            from langchain_glean.retrievers.search import GleanSearchRetriever
+
+            search = GleanSearchRetriever()
+
+        with patch("langchain_glean.retrievers.people.Glean"):
+            from langchain_glean.retrievers.people import GleanPeopleProfileRetriever
+
+            people = GleanPeopleProfileRetriever()
+
+        # Both should have resolved the same env vars
+        assert search.instance == "test-instance"
+        assert people.instance == "test-instance"
+        assert search.api_token == "test-token"
+        assert people.api_token == "test-token"

--- a/tests/unit_tests/test_glean_search_tool.py
+++ b/tests/unit_tests/test_glean_search_tool.py
@@ -1,0 +1,213 @@
+import os
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_core.documents import Document
+
+from langchain_glean.retrievers.search import GleanSearchRetriever, SearchBasicRequest
+from langchain_glean.tools.search import GleanSearchTool
+
+
+class TestGleanSearchTool:
+    """Test the GleanSearchTool class."""
+
+    @pytest.fixture(autouse=True)
+    def setup_method(self):
+        """Set up the test environment."""
+        # Create mock retriever
+        self.mock_retriever = MagicMock(spec=GleanSearchRetriever)
+
+        # Set up sample documents for retriever responses
+        self.sample_doc1 = Document(
+            page_content="Glean is an enterprise search platform.",
+            metadata={
+                "title": "About Glean",
+                "url": "https://example.com/about-glean",
+                "datasource": "Confluence",
+            },
+        )
+
+        self.sample_doc2 = Document(
+            page_content="Glean uses AI to improve search results.",
+            metadata={
+                "title": "Glean AI Features",
+                "url": "https://example.com/glean-ai",
+                "datasource": "Google Drive",
+            },
+        )
+
+        # Set up mock responses
+        self.mock_retriever.invoke.return_value = [self.sample_doc1, self.sample_doc2]
+        self.mock_retriever.ainvoke.return_value = [self.sample_doc1, self.sample_doc2]
+
+        # Initialize the tool with the mock retriever
+        self.tool = GleanSearchTool(retriever=self.mock_retriever)
+
+        yield
+
+    def test_init(self) -> None:
+        """Test the initialization of the tool."""
+        assert self.tool.name == "glean_search"
+        assert "Search for information in Glean" in self.tool.description
+        assert self.tool.retriever == self.mock_retriever
+        assert self.tool.args_schema == SearchBasicRequest
+        assert not self.tool.return_direct
+
+    def test_run_with_string_query(self) -> None:
+        """Test _run with a plain string query."""
+        result = self.tool._run("enterprise search")
+
+        self.mock_retriever.invoke.assert_called_once_with("enterprise search")
+
+        assert "Result 1: About Glean (Confluence)" in result
+        assert "URL: https://example.com/about-glean" in result
+        assert "Content: Glean is an enterprise search platform." in result
+        assert "Result 2: Glean AI Features (Google Drive)" in result
+        assert "URL: https://example.com/glean-ai" in result
+        assert "Content: Glean uses AI to improve search results." in result
+
+    def test_run_with_search_basic_request(self) -> None:
+        """Test _run with a SearchBasicRequest input."""
+        request = SearchBasicRequest(query="enterprise search")
+
+        result = self.tool._run(request)
+
+        self.mock_retriever.invoke.assert_called_once_with(request)
+
+        assert "Result 1: About Glean (Confluence)" in result
+        assert "Result 2: Glean AI Features (Google Drive)" in result
+
+    def test_run_with_dict_query(self) -> None:
+        """Test _run with a dictionary input (pops 'query' key, passes rest as kwargs)."""
+        result = self.tool._run({"query": "enterprise search", "page_size": 5})
+
+        self.mock_retriever.invoke.assert_called_once_with("enterprise search", page_size=5)
+
+        assert "Result 1: About Glean (Confluence)" in result
+
+    def test_run_with_dict_no_query_key(self) -> None:
+        """Test _run with a dict that has no 'query' key defaults to empty string."""
+        result = self.tool._run({"page_size": 5})
+
+        self.mock_retriever.invoke.assert_called_once_with("", page_size=5)
+
+        assert "Result 1: About Glean (Confluence)" in result
+
+    def test_run_with_no_results(self) -> None:
+        """Test _run when no results are found."""
+        self.mock_retriever.invoke.return_value = []
+
+        result = self.tool._run("nonexistent topic")
+
+        assert result == "No results found."
+
+    def test_run_with_missing_metadata(self) -> None:
+        """Test _run with documents that have missing metadata fields."""
+        doc = Document(page_content="Some content", metadata={})
+        self.mock_retriever.invoke.return_value = [doc]
+
+        result = self.tool._run("test query")
+
+        assert "Result 1: Untitled (Unknown Source)" in result
+        assert "URL: No URL" in result
+        assert "Content: Some content" in result
+
+    def test_run_with_glean_error(self) -> None:
+        """Test _run when a GleanError occurs."""
+        from glean.api_client import errors
+
+        mock_response = MagicMock()
+        mock_response.text = "Raw error response"
+        error = errors.GleanError("Search failed", raw_response=mock_response)
+        self.mock_retriever.invoke.side_effect = error
+
+        result = self.tool._run("test query")
+
+        assert "Glean API error" in result
+        assert "Search failed" in result
+
+    def test_run_with_glean_error_no_raw_response_text(self) -> None:
+        """Test _run when a GleanError occurs with empty raw_response text."""
+        from glean.api_client import errors
+
+        mock_response = MagicMock()
+        mock_response.text = ""
+        error = errors.GleanError("Search failed", raw_response=mock_response)
+        # Ensure raw_response is falsy for the hasattr+truthy check
+        error.raw_response = None
+        self.mock_retriever.invoke.side_effect = error
+
+        result = self.tool._run("test query")
+
+        assert "Glean API error" in result
+        assert "Search failed" in result
+
+    def test_run_with_generic_exception(self) -> None:
+        """Test _run when a generic exception occurs."""
+        self.mock_retriever.invoke.side_effect = Exception("Something went wrong")
+
+        result = self.tool._run("test query")
+
+        assert "Error running Glean search" in result
+        assert "Something went wrong" in result
+
+    async def test_arun_with_string_query(self) -> None:
+        """Test _arun with a plain string query."""
+        result = await self.tool._arun("enterprise search")
+
+        self.mock_retriever.ainvoke.assert_called_once_with("enterprise search")
+
+        assert "Result 1: About Glean (Confluence)" in result
+        assert "URL: https://example.com/about-glean" in result
+        assert "Content: Glean is an enterprise search platform." in result
+        assert "Result 2: Glean AI Features (Google Drive)" in result
+
+    async def test_arun_with_search_basic_request(self) -> None:
+        """Test _arun with a SearchBasicRequest input."""
+        request = SearchBasicRequest(query="enterprise search")
+
+        result = await self.tool._arun(request)
+
+        self.mock_retriever.ainvoke.assert_called_once_with(request)
+
+        assert "Result 1: About Glean (Confluence)" in result
+        assert "Result 2: Glean AI Features (Google Drive)" in result
+
+    async def test_arun_with_dict_query(self) -> None:
+        """Test _arun with a dictionary input."""
+        result = await self.tool._arun({"query": "enterprise search", "page_size": 5})
+
+        self.mock_retriever.ainvoke.assert_called_once_with("enterprise search", page_size=5)
+
+        assert "Result 1: About Glean (Confluence)" in result
+
+    async def test_arun_with_no_results(self) -> None:
+        """Test _arun when no results are found."""
+        self.mock_retriever.ainvoke.return_value = []
+
+        result = await self.tool._arun("nonexistent topic")
+
+        assert result == "No results found."
+
+    async def test_arun_with_glean_error(self) -> None:
+        """Test _arun when a GleanError occurs."""
+        from glean.api_client import errors
+
+        mock_response = MagicMock()
+        mock_response.text = "Raw error response"
+        error = errors.GleanError("Search failed", raw_response=mock_response)
+        self.mock_retriever.ainvoke.side_effect = error
+
+        result = await self.tool._arun("test query")
+
+        assert "Glean API error" in result
+        assert "Search failed" in result
+
+    async def test_arun_with_generic_exception(self) -> None:
+        """Test _arun when a generic exception occurs."""
+        self.mock_retriever.ainvoke.side_effect = Exception("Something went wrong")
+
+        result = await self.tool._arun("test query")
+
+        assert "Error running Glean search" in result
+        assert "Something went wrong" in result

--- a/tests/unit_tests/test_glean_toolkit.py
+++ b/tests/unit_tests/test_glean_toolkit.py
@@ -1,28 +1,111 @@
 import os
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from langchain_glean.toolkit import GleanToolkit
 from langchain_glean.tools.chat import GleanChatTool
+from langchain_glean.tools.get_agent_schema import GleanGetAgentSchemaTool
+from langchain_glean.tools.list_agents import GleanListAgentsTool
 from langchain_glean.tools.people_profile_search import GleanPeopleProfileSearchTool
+from langchain_glean.tools.run_agent import GleanRunAgentTool
 from langchain_glean.tools.search import GleanSearchTool
 
 
 class TestGleanToolkit:
     """Verify that the toolkit returns the expected tools."""
 
-    def test_get_tools(self) -> None:
+    @pytest.fixture(autouse=True)
+    def setup_method(self):
+        """Set up the test environment."""
         os.environ["GLEAN_INSTANCE"] = "test-glean"
         os.environ["GLEAN_API_TOKEN"] = "test-token"
         os.environ["GLEAN_ACT_AS"] = "test@example.com"
 
-        with patch("langchain_glean.retrievers.people.Glean"), patch("langchain_glean.retrievers.search.Glean"):
-            tk = GleanToolkit()
-            tools = tk.get_tools()
+        self.mock_people_glean_patcher = patch("langchain_glean.retrievers.people.Glean")
+        self.mock_search_glean_patcher = patch("langchain_glean.retrievers.search.Glean")
+        self.mock_people_glean_patcher.start()
+        self.mock_search_glean_patcher.start()
 
-        assert len(tools) == 6
-        assert any(isinstance(t, GleanChatTool) for t in tools)
-        assert any(isinstance(t, GleanPeopleProfileSearchTool) for t in tools)
-        assert any(isinstance(t, GleanSearchTool) for t in tools)
+        yield
+
+        self.mock_people_glean_patcher.stop()
+        self.mock_search_glean_patcher.stop()
 
         for var in ["GLEAN_INSTANCE", "GLEAN_API_TOKEN", "GLEAN_ACT_AS"]:
             os.environ.pop(var, None)
+
+    def test_get_tools_returns_six_tools(self) -> None:
+        """Test that get_tools returns exactly six tools."""
+        tk = GleanToolkit()
+        tools = tk.get_tools()
+
+        assert len(tools) == 6
+
+    def test_get_tools_contains_all_tool_types(self) -> None:
+        """Test that get_tools returns one of each expected tool type."""
+        tk = GleanToolkit()
+        tools = tk.get_tools()
+
+        expected_types = [
+            GleanChatTool,
+            GleanPeopleProfileSearchTool,
+            GleanSearchTool,
+            GleanListAgentsTool,
+            GleanGetAgentSchemaTool,
+            GleanRunAgentTool,
+        ]
+
+        for tool_type in expected_types:
+            matching = [t for t in tools if isinstance(t, tool_type)]
+            assert len(matching) == 1, f"Expected exactly one {tool_type.__name__}, found {len(matching)}"
+
+    def test_get_tools_unique_names(self) -> None:
+        """Test that all tools have unique names."""
+        tk = GleanToolkit()
+        tools = tk.get_tools()
+        names = [t.name for t in tools]
+
+        assert len(names) == len(set(names)), f"Duplicate tool names found: {names}"
+
+    def test_search_tool_uses_provided_search_retriever(self) -> None:
+        """Test that the GleanSearchTool uses the toolkit's search_retriever."""
+        tk = GleanToolkit()
+        tools = tk.get_tools()
+        search_tool = next(t for t in tools if isinstance(t, GleanSearchTool))
+
+        assert search_tool.retriever is tk.search_retriever
+
+    def test_people_tool_uses_provided_people_retriever(self) -> None:
+        """Test that the GleanPeopleProfileSearchTool uses the toolkit's people_retriever."""
+        tk = GleanToolkit()
+        tools = tk.get_tools()
+        people_tool = next(t for t in tools if isinstance(t, GleanPeopleProfileSearchTool))
+
+        assert people_tool.retriever is tk.people_retriever
+
+    def test_custom_retrievers(self) -> None:
+        """Test that custom retrievers can be passed to the toolkit."""
+        from langchain_glean.retrievers.people import GleanPeopleProfileRetriever
+        from langchain_glean.retrievers.search import GleanSearchRetriever
+
+        custom_search = MagicMock(spec=GleanSearchRetriever)
+        custom_people = MagicMock(spec=GleanPeopleProfileRetriever)
+
+        tk = GleanToolkit(search_retriever=custom_search, people_retriever=custom_people)
+        tools = tk.get_tools()
+
+        search_tool = next(t for t in tools if isinstance(t, GleanSearchTool))
+        people_tool = next(t for t in tools if isinstance(t, GleanPeopleProfileSearchTool))
+
+        assert search_tool.retriever is custom_search
+        assert people_tool.retriever is custom_people
+
+    def test_toolkit_without_act_as(self) -> None:
+        """Test that the toolkit works without GLEAN_ACT_AS set."""
+        os.environ.pop("GLEAN_ACT_AS", None)
+
+        tk = GleanToolkit()
+        tools = tk.get_tools()
+
+        assert len(tools) == 6


### PR DESCRIPTION
## Description

Adds missing unit tests to close coverage gaps in the test suite:

- **GleanSearchTool** (`tools/search.py`): Added 16 unit tests covering all three input styles (string, `SearchBasicRequest`, dict), output formatting, missing metadata defaults, empty results, `GleanError` and generic exception handling, and async variants. Previously had no dedicated unit tests.
- **GleanToolkit** (`toolkit.py`): Expanded from 1 test to 7 tests covering tool type verification, unique tool names, retriever injection, custom retrievers, and optional `act_as`. Previously only verified the tool count.
- **GleanAPIClientMixin** (`_api_client_mixin.py`): Added 11 dedicated unit tests covering environment variable resolution, constructor argument precedence, missing credential validation, `act_as` handling, `_http_headers()` generation, and cross-class consistency. Previously only tested indirectly.

Total: **34 new tests** (119 total unit tests, all passing).

## Testing

- All 34 new tests pass locally
- All 119 unit tests pass with no regressions to existing tests

___
🤖 *Generated by Glean Code Writer*
📝 Chat link - https://app.glean.com/chat/ce5a7407b2c4474e887192deb64268d5