### PR TITLE
feat: add server_url support with instance fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-GLEAN_SERVER_URL=https://your-instance-be.glean.com
-# OR legacy:
+GLEAN_SERVER_URL=https://your-company-be.glean.com
+# Deprecated: GLEAN_INSTANCE is still supported as a fallback
 # GLEAN_INSTANCE=your-instance
 GLEAN_API_TOKEN=your-api-token
 GLEAN_ACT_AS=user@example.com

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
-GLEAN_INSTANCE=your-instance
+GLEAN_SERVER_URL=https://your-instance-be.glean.com
+# OR legacy:
+# GLEAN_INSTANCE=your-instance
 GLEAN_API_TOKEN=your-api-token
 GLEAN_ACT_AS=user@example.com
 VERBOSE=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ langchain_glean/
 
 ### Key Patterns
 
-- **GleanAPIClientMixin**: All components inherit from this mixin, which resolves `GLEAN_INSTANCE`, `GLEAN_API_TOKEN`, and `GLEAN_ACT_AS` from environment variables or constructor args.
+- **GleanAPIClientMixin**: All components inherit from this mixin, which resolves `GLEAN_SERVER_URL` (preferred) or `GLEAN_INSTANCE`, `GLEAN_API_TOKEN`, and `GLEAN_ACT_AS` from environment variables or constructor args. Use `_build_glean_client()` to create SDK clients.
 - **Async support**: Every retriever/tool exposes `ainvoke`, `astream` via the standard LangChain async interface.
 - **Message conversion**: `ChatGlean._convert_message_to_glean_format()` maps LangChain messages to Glean's `ChatMessage` format (author, message_type, fragments).
 
@@ -70,7 +70,7 @@ langchain_glean/
 
 - Unit tests mock the Glean SDK at the module boundary (e.g., `patch("langchain_glean.retrievers.search.Glean")`)
 - Network is disabled via `--disable-socket` for unit tests
-- Integration tests require real `GLEAN_API_TOKEN` and `GLEAN_INSTANCE` environment variables
+- Integration tests require real `GLEAN_API_TOKEN` and `GLEAN_SERVER_URL` (or `GLEAN_INSTANCE`) environment variables
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ pip install -U langchain-glean
 
 ```bash
 export GLEAN_API_TOKEN="<your-token>"              # user or global token
-export GLEAN_SERVER_URL="https://acme-be.glean.com" # preferred — full backend URL
-# OR legacy:
-export GLEAN_INSTANCE="acme"                       # Glean instance name
+export GLEAN_SERVER_URL="https://your-company-be.glean.com" # full backend URL (preferred)
+# Deprecated: GLEAN_INSTANCE is still supported as a fallback
+# export GLEAN_INSTANCE="acme"
 export GLEAN_ACT_AS="user@acme.com"                # only for global tokens
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ pip install -U langchain-glean
 ### Environment variables
 
 ```bash
-export GLEAN_API_TOKEN="<your-token>"   # user or global token
-export GLEAN_INSTANCE="acme"            # Glean instance name
-export GLEAN_ACT_AS="user@acme.com"     # only for global tokens
+export GLEAN_API_TOKEN="<your-token>"              # user or global token
+export GLEAN_SERVER_URL="https://acme-be.glean.com" # preferred — full backend URL
+# OR legacy:
+export GLEAN_INSTANCE="acme"                       # Glean instance name
+export GLEAN_ACT_AS="user@acme.com"                # only for global tokens
 ```
 
 ## Quick Start

--- a/langchain_glean/_api_client_mixin.py
+++ b/langchain_glean/_api_client_mixin.py
@@ -14,13 +14,11 @@ class GleanAPIClientMixin:  # noqa: D401
 
     server_url: Optional[str] = Field(
         default=None,
-        description="Full Glean backend URL (e.g. 'https://acme-be.glean.com'). "
-                    "Preferred over instance. Falls back to GLEAN_SERVER_URL env var.",
+        description="Full Glean backend URL (e.g. 'https://acme-be.glean.com'). Preferred over instance. Falls back to GLEAN_SERVER_URL env var.",
     )
     instance: str = Field(
         default="",
-        description="Glean instance/subdomain (e.g. 'acme'). "
-                    "Legacy — prefer server_url. Falls back to GLEAN_INSTANCE env var.",
+        description="Glean instance/subdomain (e.g. 'acme'). Legacy — prefer server_url. Falls back to GLEAN_INSTANCE env var.",
     )
     api_token: str = Field(description="Glean API token (user or global)")
     act_as: Optional[str] = Field(

--- a/langchain_glean/_api_client_mixin.py
+++ b/langchain_glean/_api_client_mixin.py
@@ -1,5 +1,7 @@
+import os
 from typing import Any, Dict, Optional
 
+from glean.api_client import Glean
 from langchain_core.utils import get_from_dict_or_env
 from pydantic import Field, model_validator
 
@@ -10,7 +12,16 @@ class GleanAPIClientMixin:  # noqa: D401
     Provides configuration for creating Glean API clients.
     """
 
-    instance: str = Field(description="Glean instance/subdomain (e.g. 'acme')")
+    server_url: Optional[str] = Field(
+        default=None,
+        description="Full Glean backend URL (e.g. 'https://acme-be.glean.com'). "
+                    "Preferred over instance. Falls back to GLEAN_SERVER_URL env var.",
+    )
+    instance: str = Field(
+        default="",
+        description="Glean instance/subdomain (e.g. 'acme'). "
+                    "Legacy — prefer server_url. Falls back to GLEAN_INSTANCE env var.",
+    )
     api_token: str = Field(description="Glean API token (user or global)")
     act_as: Optional[str] = Field(
         default=None,
@@ -21,10 +32,19 @@ class GleanAPIClientMixin:  # noqa: D401
     @classmethod
     def _resolve_env(cls, values: Dict[str, Any]) -> Dict[str, Any]:  # noqa: D401, ANN001
         values = values or {}
-        values["instance"] = get_from_dict_or_env(values, "instance", "GLEAN_INSTANCE")
+        if not values.get("server_url"):
+            values["server_url"] = os.environ.get("GLEAN_SERVER_URL", "")
+        if not values.get("server_url") and not values.get("instance"):
+            values["instance"] = get_from_dict_or_env(values, "instance", "GLEAN_INSTANCE")
         values["api_token"] = get_from_dict_or_env(values, "api_token", "GLEAN_API_TOKEN")
         values["act_as"] = get_from_dict_or_env(values, "act_as", "GLEAN_ACT_AS", default="")
         return values
+
+    def _build_glean_client(self) -> Glean:
+        """Create a Glean SDK client using server_url (preferred) or instance."""
+        if self.server_url:
+            return Glean(server_url=self.server_url, api_token=self.api_token)
+        return Glean(instance=self.instance, api_token=self.api_token)
 
     def _http_headers(self) -> Optional[Dict[str, str]]:
         """Return HTTP headers for impersonation if ``act_as`` is set."""

--- a/langchain_glean/chat_models/agent_chat.py
+++ b/langchain_glean/chat_models/agent_chat.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional, cast
 
-from glean.api_client import Glean, errors, models
+from glean.api_client import errors, models
 from langchain_core.callbacks import AsyncCallbackManagerForLLMRun, CallbackManagerForLLMRun
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
@@ -40,7 +40,7 @@ class ChatGleanAgent(GleanAPIClientMixin, BaseChatModel):
             fields["input"] = user_input
 
         try:
-            with Glean(api_token=self.api_token, instance=self.instance) as g:
+            with self._build_glean_client() as g:
                 response = g.client.agents.run(agent_id=self.agent_id, input=fields)
         except errors.GleanError as e:
             raise ValueError(f"Glean client error: {e}") from e
@@ -97,7 +97,7 @@ class ChatGleanAgent(GleanAPIClientMixin, BaseChatModel):
             fields["input"] = user_input
 
         try:
-            with Glean(api_token=self.api_token, instance=self.instance) as g:
+            with self._build_glean_client() as g:
                 response = await g.client.agents.run_async(agent_id=self.agent_id, input=fields)
         except errors.GleanError as e:
             raise ValueError(f"Glean client error: {e}") from e

--- a/langchain_glean/chat_models/chat.py
+++ b/langchain_glean/chat_models/chat.py
@@ -41,8 +41,9 @@ class ChatGlean(GleanAPIClientMixin, BaseChatModel):
 
             pip install -U langchain-glean
             export GLEAN_API_TOKEN="your-api-token"   # user or global token
-            export GLEAN_SERVER_URL="https://acme-be.glean.com"  # preferred
-            # OR legacy: export GLEAN_INSTANCE="acme"
+            export GLEAN_SERVER_URL="https://your-company-be.glean.com"  # full backend URL (preferred)
+            # Deprecated: GLEAN_INSTANCE is still supported as a fallback
+            # export GLEAN_INSTANCE="acme"
             export GLEAN_ACT_AS="user@example.com"    # only for global tokens
 
     Key init args
@@ -52,7 +53,7 @@ class ChatGlean(GleanAPIClientMixin, BaseChatModel):
     server_url : str, optional
         Full Glean backend URL (``GLEAN_SERVER_URL``). Preferred over instance.
     instance : str, optional
-        Glean instance / sub-domain (``GLEAN_INSTANCE``). Legacy — prefer server_url.
+        (Deprecated) Glean instance / sub-domain (``GLEAN_INSTANCE``). Use server_url instead.
     act_as : str, optional
         Email to impersonate when using a global token (``GLEAN_ACT_AS``).
     chat_id : str, optional
@@ -74,7 +75,7 @@ class ChatGlean(GleanAPIClientMixin, BaseChatModel):
         from langchain_glean.chat_models import ChatGlean
 
         chat = ChatGlean()                      # reads env-vars
-        chat = ChatGlean(api_token="token", server_url="https://acme-be.glean.com")
+        chat = ChatGlean(api_token="token", server_url="https://your-company-be.glean.com")
 
     Invoke
     ------

--- a/langchain_glean/chat_models/chat.py
+++ b/langchain_glean/chat_models/chat.py
@@ -1,6 +1,6 @@
 from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Union, cast
 
-from glean.api_client import Glean, errors, models  # noqa: F401
+from glean.api_client import errors, models
 from langchain_core.callbacks import (
     AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
@@ -41,15 +41,18 @@ class ChatGlean(GleanAPIClientMixin, BaseChatModel):
 
             pip install -U langchain-glean
             export GLEAN_API_TOKEN="your-api-token"   # user or global token
-            export GLEAN_INSTANCE="acme"              # your Glean sub-domain
+            export GLEAN_SERVER_URL="https://acme-be.glean.com"  # preferred
+            # OR legacy: export GLEAN_INSTANCE="acme"
             export GLEAN_ACT_AS="user@example.com"    # only for global tokens
 
     Key init args
     -------------
     api_token : str, optional
         Glean API token.  Falls back to ``GLEAN_API_TOKEN``.
+    server_url : str, optional
+        Full Glean backend URL (``GLEAN_SERVER_URL``). Preferred over instance.
     instance : str, optional
-        Glean instance / sub-domain (``GLEAN_INSTANCE``).
+        Glean instance / sub-domain (``GLEAN_INSTANCE``). Legacy — prefer server_url.
     act_as : str, optional
         Email to impersonate when using a global token (``GLEAN_ACT_AS``).
     chat_id : str, optional
@@ -71,7 +74,7 @@ class ChatGlean(GleanAPIClientMixin, BaseChatModel):
         from langchain_glean.chat_models import ChatGlean
 
         chat = ChatGlean()                      # reads env-vars
-        chat = ChatGlean(api_token="token", instance="acme")
+        chat = ChatGlean(api_token="token", server_url="https://acme-be.glean.com")
 
     Invoke
     ------
@@ -267,7 +270,7 @@ class ChatGlean(GleanAPIClientMixin, BaseChatModel):
             params = self._build_chat_params(cast(List[BaseMessage], messages), **kwargs)
 
         try:
-            with Glean(api_token=self.api_token, instance=self.instance) as g:
+            with self._build_glean_client() as g:
                 headers = self._http_headers()
                 response = g.client.chat.create(
                     messages=params.messages,
@@ -360,7 +363,7 @@ class ChatGlean(GleanAPIClientMixin, BaseChatModel):
             params = self._build_chat_params(cast(List[BaseMessage], messages), **kwargs)
 
         try:
-            with Glean(api_token=self.api_token, instance=self.instance) as g:
+            with self._build_glean_client() as g:
                 headers = self._http_headers()
                 response = await g.client.chat.create_async(
                     messages=params.messages,
@@ -455,7 +458,7 @@ class ChatGlean(GleanAPIClientMixin, BaseChatModel):
         params.stream = True
 
         try:
-            with Glean(api_token=self.api_token, instance=self.instance) as g:
+            with self._build_glean_client() as g:
                 headers = self._http_headers()
                 response_stream = g.client.chat.create_stream(
                     messages=params.messages,
@@ -548,7 +551,7 @@ class ChatGlean(GleanAPIClientMixin, BaseChatModel):
         params.stream = True
 
         try:
-            with Glean(api_token=self.api_token, instance=self.instance) as g:
+            with self._build_glean_client() as g:
                 headers = self._http_headers()
                 response_stream = await g.client.chat.create_stream_async(
                     messages=params.messages,

--- a/langchain_glean/retrievers/people.py
+++ b/langchain_glean/retrievers/people.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Union
 
-from glean.api_client import Glean, errors, models
+from glean.api_client import errors, models
 from langchain_core.callbacks import (
     AsyncCallbackManagerForRetrieverRun,
     CallbackManagerForRetrieverRun,
@@ -127,7 +127,7 @@ class GleanPeopleProfileRetriever(GleanAPIClientMixin, BaseRetriever):
     ) -> List[Document]:
         try:
             entities_req = self._build_entities_request(query, **kwargs)
-            with Glean(api_token=self.api_token, instance=self.instance) as g:
+            with self._build_glean_client() as g:
                 # Use vars() instead of model_dump() due to SDK's custom serializer
                 params = {k: v for k, v in vars(entities_req).items() if not k.startswith("_") and v is not None}
                 response = g.client.entities.list(**params)
@@ -163,7 +163,7 @@ class GleanPeopleProfileRetriever(GleanAPIClientMixin, BaseRetriever):
     ) -> List[Document]:
         try:
             entities_req = self._build_entities_request(query, **kwargs)
-            with Glean(api_token=self.api_token, instance=self.instance) as g:
+            with self._build_glean_client() as g:
                 # Use vars() instead of model_dump() due to SDK's custom serializer
                 params = {k: v for k, v in vars(entities_req).items() if not k.startswith("_") and v is not None}
                 response = await g.client.entities.list_async(**params)

--- a/langchain_glean/retrievers/people.py
+++ b/langchain_glean/retrievers/people.py
@@ -54,14 +54,16 @@ class GleanPeopleProfileRetriever(GleanAPIClientMixin, BaseRetriever):
 
     Setup:
         Install ``langchain-glean`` and set environment variables
-        ``GLEAN_API_TOKEN`` and ``GLEAN_INSTANCE``. Optionally set ``GLEAN_ACT_AS``
+        ``GLEAN_API_TOKEN`` and ``GLEAN_SERVER_URL``. Optionally set ``GLEAN_ACT_AS``
         if using a global token.
 
         .. code-block:: bash
 
             pip install -U langchain-glean
             export GLEAN_API_TOKEN="your-api-token"  # Can be a global or user token
-            export GLEAN_INSTANCE="your-glean-subdomain"
+            export GLEAN_SERVER_URL="https://your-company-be.glean.com"  # full backend URL (preferred)
+            # Deprecated: GLEAN_INSTANCE is still supported as a fallback
+            # export GLEAN_INSTANCE="your-glean-subdomain"
             export GLEAN_ACT_AS="user@example.com"  # Only required for global tokens
 
     Example:

--- a/langchain_glean/retrievers/search.py
+++ b/langchain_glean/retrievers/search.py
@@ -40,14 +40,16 @@ class GleanSearchRetriever(GleanAPIClientMixin, BaseRetriever):
 
     Setup:
         Install ``langchain-glean`` and set environment variables
-        ``GLEAN_API_TOKEN`` and ``GLEAN_INSTANCE``. Optionally set ``GLEAN_ACT_AS``
+        ``GLEAN_API_TOKEN`` and ``GLEAN_SERVER_URL``. Optionally set ``GLEAN_ACT_AS``
         if using a global token.
 
         .. code-block:: bash
 
             pip install -U langchain-glean
             export GLEAN_API_TOKEN="your-api-token"  # Can be a global or user token
-            export GLEAN_INSTANCE="your-glean-subdomain"
+            export GLEAN_SERVER_URL="https://your-company-be.glean.com"  # full backend URL (preferred)
+            # Deprecated: GLEAN_INSTANCE is still supported as a fallback
+            # export GLEAN_INSTANCE="your-glean-subdomain"
             export GLEAN_ACT_AS="user@example.com"  # Only required for global tokens
 
     Example:

--- a/langchain_glean/retrievers/search.py
+++ b/langchain_glean/retrievers/search.py
@@ -1,7 +1,7 @@
 # ruff: noqa: I001
 from typing import Any, Iterable, List, Optional, Union
 
-from glean.api_client import Glean, errors, models
+from glean.api_client import errors, models
 from langchain_core.callbacks import (
     AsyncCallbackManagerForRetrieverRun,
     CallbackManagerForRetrieverRun,
@@ -129,7 +129,7 @@ class GleanSearchRetriever(GleanAPIClientMixin, BaseRetriever):
             search_request = self._build_search_request(query, **kwargs)
 
             try:
-                with Glean(api_token=self.api_token, instance=self.instance) as g:
+                with self._build_glean_client() as g:
                     headers = self._http_headers()
                     # Use vars() instead of model_dump() due to SDK's custom serializer
                     params = {k: v for k, v in vars(search_request).items() if not k.startswith("_") and v is not None}
@@ -180,7 +180,7 @@ class GleanSearchRetriever(GleanAPIClientMixin, BaseRetriever):
             search_request = self._build_search_request(query, **kwargs)
 
             try:
-                with Glean(api_token=self.api_token, instance=self.instance) as g:
+                with self._build_glean_client() as g:
                     headers = self._http_headers()
                     # Use vars() instead of model_dump() due to SDK's custom serializer
                     params = {k: v for k, v in vars(search_request).items() if not k.startswith("_") and v is not None}

--- a/langchain_glean/tools/get_agent_schema.py
+++ b/langchain_glean/tools/get_agent_schema.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from glean.api_client import Glean, errors
+from glean.api_client import errors
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field
 
@@ -21,7 +21,7 @@ class GleanGetAgentSchemaTool(GleanAPIClientMixin, BaseTool):
 
     def _run(self, agent_id: str, **kwargs: Any) -> str:  # noqa: D401
         try:
-            with Glean(api_token=self.api_token, instance=self.instance) as g:
+            with self._build_glean_client() as g:
                 response = g.client.agents.retrieve_schemas(agent_id=agent_id)
 
             if hasattr(response, "model_dump_json"):
@@ -38,7 +38,7 @@ class GleanGetAgentSchemaTool(GleanAPIClientMixin, BaseTool):
 
     async def _arun(self, agent_id: str, **kwargs: Any) -> str:  # noqa: D401
         try:
-            with Glean(api_token=self.api_token, instance=self.instance) as g:
+            with self._build_glean_client() as g:
                 response = await g.client.agents.retrieve_schemas_async(agent_id=agent_id)
 
             if hasattr(response, "model_dump_json"):

--- a/langchain_glean/tools/list_agents.py
+++ b/langchain_glean/tools/list_agents.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from glean.api_client import Glean, errors
+from glean.api_client import errors
 from langchain_core.tools import BaseTool
 
 from langchain_glean._api_client_mixin import GleanAPIClientMixin
@@ -14,7 +14,7 @@ class GleanListAgentsTool(GleanAPIClientMixin, BaseTool):
 
     def _run(self, **kwargs: Any) -> str:  # noqa: D401
         try:
-            with Glean(api_token=self.api_token, instance=self.instance) as g:
+            with self._build_glean_client() as g:
                 response = g.client.agents.list()
 
             if hasattr(response, "model_dump_json"):
@@ -31,7 +31,7 @@ class GleanListAgentsTool(GleanAPIClientMixin, BaseTool):
 
     async def _arun(self, **kwargs: Any) -> str:  # noqa: D401
         try:
-            with Glean(api_token=self.api_token, instance=self.instance) as g:
+            with self._build_glean_client() as g:
                 response = await g.client.agents.list_async()
 
             if hasattr(response, "model_dump_json"):

--- a/langchain_glean/tools/run_agent.py
+++ b/langchain_glean/tools/run_agent.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from glean.api_client import Glean, errors
+from glean.api_client import errors
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field
 
@@ -23,7 +23,7 @@ class GleanRunAgentTool(GleanAPIClientMixin, BaseTool):
 
     def _run(self, agent_id: str, fields: Dict[str, str], **kwargs: Any) -> str:  # noqa: D401
         try:
-            with Glean(api_token=self.api_token, instance=self.instance) as g:
+            with self._build_glean_client() as g:
                 response = g.client.agents.run(agent_id=agent_id, input=fields)
 
             if hasattr(response, "model_dump_json"):
@@ -40,7 +40,7 @@ class GleanRunAgentTool(GleanAPIClientMixin, BaseTool):
 
     async def _arun(self, agent_id: str, fields: Dict[str, str], **kwargs: Any) -> str:  # noqa: D401
         try:
-            with Glean(api_token=self.api_token, instance=self.instance) as g:
+            with self._build_glean_client() as g:
                 response = await g.client.agents.run_async(agent_id=agent_id, input=fields)
 
             if hasattr(response, "model_dump_json"):

--- a/tests/integration_tests/test_end_to_end.py
+++ b/tests/integration_tests/test_end_to_end.py
@@ -20,7 +20,7 @@ class TestEndToEndWorkflows(unittest.TestCase):
 
         load_dotenv(override=True)
 
-        if not os.environ.get("GLEAN_INSTANCE") or not os.environ.get("GLEAN_API_TOKEN"):
+        if not (os.environ.get("GLEAN_SERVER_URL") or os.environ.get("GLEAN_INSTANCE")) or not os.environ.get("GLEAN_API_TOKEN"):
             self.skipTest("Glean credentials not found in environment variables")
 
     def test_search_to_chat_workflow(self) -> None:

--- a/tests/integration_tests/test_glean_agent_chat_model.py
+++ b/tests/integration_tests/test_glean_agent_chat_model.py
@@ -23,7 +23,7 @@ class TestGleanAgentChatModelIntegration(unittest.TestCase):
 
         load_dotenv(override=True)
 
-        if not os.environ.get("GLEAN_INSTANCE") or not os.environ.get("GLEAN_API_TOKEN"):
+        if not (os.environ.get("GLEAN_SERVER_URL") or os.environ.get("GLEAN_INSTANCE")) or not os.environ.get("GLEAN_API_TOKEN"):
             self.skipTest("Glean credentials not found in environment variables")
 
         # Define a test agent ID - this should be a valid agent ID in your Glean instance

--- a/tests/integration_tests/test_glean_chat_model.py
+++ b/tests/integration_tests/test_glean_chat_model.py
@@ -24,7 +24,7 @@ class TestGleanChatModelIntegration(unittest.TestCase):
 
         load_dotenv(override=True)
 
-        if not os.environ.get("GLEAN_INSTANCE") or not os.environ.get("GLEAN_API_TOKEN"):
+        if not (os.environ.get("GLEAN_SERVER_URL") or os.environ.get("GLEAN_INSTANCE")) or not os.environ.get("GLEAN_API_TOKEN"):
             self.skipTest("Glean credentials not found in environment variables")
 
     @property

--- a/tests/integration_tests/test_glean_chat_tool.py
+++ b/tests/integration_tests/test_glean_chat_tool.py
@@ -17,7 +17,7 @@ class TestGleanChatTool(unittest.TestCase):
 
         load_dotenv(override=True)
 
-        if not os.environ.get("GLEAN_INSTANCE") or not os.environ.get("GLEAN_API_TOKEN"):
+        if not (os.environ.get("GLEAN_SERVER_URL") or os.environ.get("GLEAN_INSTANCE")) or not os.environ.get("GLEAN_API_TOKEN"):
             self.skipTest("Glean credentials not found in environment variables")
 
     @property

--- a/tests/integration_tests/test_glean_get_agent_schema_tool.py
+++ b/tests/integration_tests/test_glean_get_agent_schema_tool.py
@@ -16,7 +16,7 @@ class TestGleanGetAgentSchemaToolIntegration(unittest.TestCase):
 
         load_dotenv(override=True)
 
-        if not os.environ.get("GLEAN_INSTANCE") or not os.environ.get("GLEAN_API_TOKEN"):
+        if not (os.environ.get("GLEAN_SERVER_URL") or os.environ.get("GLEAN_INSTANCE")) or not os.environ.get("GLEAN_API_TOKEN"):
             self.skipTest("Glean credentials not found in environment variables")
 
         # Define a test agent ID - this should be a valid agent ID in your Glean instance

--- a/tests/integration_tests/test_glean_list_agents_tool.py
+++ b/tests/integration_tests/test_glean_list_agents_tool.py
@@ -16,7 +16,7 @@ class TestGleanListAgentsToolIntegration(unittest.TestCase):
 
         load_dotenv(override=True)
 
-        if not os.environ.get("GLEAN_INSTANCE") or not os.environ.get("GLEAN_API_TOKEN"):
+        if not (os.environ.get("GLEAN_SERVER_URL") or os.environ.get("GLEAN_INSTANCE")) or not os.environ.get("GLEAN_API_TOKEN"):
             self.skipTest("Glean credentials not found in environment variables")
 
         # Initialize the tool

--- a/tests/integration_tests/test_glean_people_profile_retriever.py
+++ b/tests/integration_tests/test_glean_people_profile_retriever.py
@@ -23,7 +23,7 @@ class TestGleanPeopleProfileRetriever(unittest.TestCase):
 
         load_dotenv(override=True)
 
-        if not os.environ.get("GLEAN_INSTANCE") or not os.environ.get("GLEAN_API_TOKEN"):
+        if not (os.environ.get("GLEAN_SERVER_URL") or os.environ.get("GLEAN_INSTANCE")) or not os.environ.get("GLEAN_API_TOKEN"):
             self.skipTest("Glean credentials not found in environment variables")
 
     @property

--- a/tests/integration_tests/test_glean_people_profile_search_tool.py
+++ b/tests/integration_tests/test_glean_people_profile_search_tool.py
@@ -17,7 +17,7 @@ class TestGleanPeopleProfileSearchTool(unittest.TestCase):
 
         load_dotenv(override=True)
 
-        if not os.environ.get("GLEAN_INSTANCE") or not os.environ.get("GLEAN_API_TOKEN"):
+        if not (os.environ.get("GLEAN_SERVER_URL") or os.environ.get("GLEAN_INSTANCE")) or not os.environ.get("GLEAN_API_TOKEN"):
             self.skipTest("Glean credentials not found in environment variables")
 
     @property

--- a/tests/integration_tests/test_glean_run_agent_tool.py
+++ b/tests/integration_tests/test_glean_run_agent_tool.py
@@ -16,7 +16,7 @@ class TestGleanRunAgentToolIntegration(unittest.TestCase):
 
         load_dotenv(override=True)
 
-        if not os.environ.get("GLEAN_INSTANCE") or not os.environ.get("GLEAN_API_TOKEN"):
+        if not (os.environ.get("GLEAN_SERVER_URL") or os.environ.get("GLEAN_INSTANCE")) or not os.environ.get("GLEAN_API_TOKEN"):
             self.skipTest("Glean credentials not found in environment variables")
 
         # Define a test agent ID - this should be a valid agent ID in your Glean instance

--- a/tests/integration_tests/test_glean_search_retriever.py
+++ b/tests/integration_tests/test_glean_search_retriever.py
@@ -24,7 +24,7 @@ class TestGleanSearchRetriever(unittest.TestCase):
 
         load_dotenv(override=True)
 
-        if not os.environ.get("GLEAN_INSTANCE") or not os.environ.get("GLEAN_API_TOKEN"):
+        if not (os.environ.get("GLEAN_SERVER_URL") or os.environ.get("GLEAN_INSTANCE")) or not os.environ.get("GLEAN_API_TOKEN"):
             self.skipTest("Glean credentials not found in environment variables")
 
     @property

--- a/tests/unit_tests/test_glean_agent_chat_model.py
+++ b/tests/unit_tests/test_glean_agent_chat_model.py
@@ -60,7 +60,7 @@ class TestGleanAgentChatModel:
         os.environ["GLEAN_API_TOKEN"] = "test-api-token"
 
         # Mock the Glean class where it's directly used
-        self.mock_glean_patcher = patch("langchain_glean.chat_models.agent_chat.Glean")
+        self.mock_glean_patcher = patch("langchain_glean._api_client_mixin.Glean")
         self.mock_glean = self.mock_glean_patcher.start()
 
         # Mock the client property of the Glean instance

--- a/tests/unit_tests/test_glean_chat_model.py
+++ b/tests/unit_tests/test_glean_chat_model.py
@@ -61,7 +61,7 @@ class TestGleanChatModel:
         os.environ["GLEAN_API_TOKEN"] = "test-api-token"
 
         # Mock the Glean class where it's directly used
-        self.mock_glean_patcher = patch("langchain_glean.chat_models.chat.Glean")
+        self.mock_glean_patcher = patch("langchain_glean._api_client_mixin.Glean")
         self.mock_glean = self.mock_glean_patcher.start()
 
         # Mock the client property of the Glean instance

--- a/tests/unit_tests/test_glean_get_agent_schema_tool.py
+++ b/tests/unit_tests/test_glean_get_agent_schema_tool.py
@@ -17,7 +17,7 @@ class TestGleanGetAgentSchemaTool:
         os.environ["GLEAN_API_TOKEN"] = "test-api-token"
 
         # Mock the Glean class where it's directly used
-        self.mock_glean_patcher = patch("langchain_glean.tools.get_agent_schema.Glean")
+        self.mock_glean_patcher = patch("langchain_glean._api_client_mixin.Glean")
         self.mock_glean = self.mock_glean_patcher.start()
 
         # Mock the client property of the Glean instance

--- a/tests/unit_tests/test_glean_list_agents_tool.py
+++ b/tests/unit_tests/test_glean_list_agents_tool.py
@@ -17,7 +17,7 @@ class TestGleanListAgentsTool:
         os.environ["GLEAN_API_TOKEN"] = "test-api-token"
 
         # Mock the Glean class where it's directly used
-        self.mock_glean_patcher = patch("langchain_glean.tools.list_agents.Glean")
+        self.mock_glean_patcher = patch("langchain_glean._api_client_mixin.Glean")
         self.mock_glean = self.mock_glean_patcher.start()
 
         # Mock the client property of the Glean instance

--- a/tests/unit_tests/test_glean_people_profile_retriever.py
+++ b/tests/unit_tests/test_glean_people_profile_retriever.py
@@ -26,7 +26,7 @@ class TestGleanPeopleProfileRetriever:
         os.environ["GLEAN_ACT_AS"] = "test@example.com"
 
         # Mock the Glean class where it's directly used
-        self.mock_glean_patcher = patch("langchain_glean.retrievers.people.Glean")
+        self.mock_glean_patcher = patch("langchain_glean._api_client_mixin.Glean")
         self.mock_glean = self.mock_glean_patcher.start()
 
         # Create mock entities client

--- a/tests/unit_tests/test_glean_run_agent_tool.py
+++ b/tests/unit_tests/test_glean_run_agent_tool.py
@@ -17,7 +17,7 @@ class TestGleanRunAgentTool:
         os.environ["GLEAN_API_TOKEN"] = "test-api-token"
 
         # Mock the Glean class where it's used directly in the tool
-        self.mock_glean_patcher = patch("langchain_glean.tools.run_agent.Glean")
+        self.mock_glean_patcher = patch("langchain_glean._api_client_mixin.Glean")
         self.mock_glean = self.mock_glean_patcher.start()
 
         # Mock the client property of the Glean instance

--- a/tests/unit_tests/test_glean_search_retriever.py
+++ b/tests/unit_tests/test_glean_search_retriever.py
@@ -27,7 +27,7 @@ class TestGleanSearchRetriever:
         os.environ["GLEAN_ACT_AS"] = "test@example.com"
 
         # Mock the Glean class where it's directly used
-        self.mock_glean_patcher = patch("langchain_glean.retrievers.search.Glean")
+        self.mock_glean_patcher = patch("langchain_glean._api_client_mixin.Glean")
         self.mock_glean = self.mock_glean_patcher.start()
 
         # Create mock search client

--- a/tests/unit_tests/test_glean_toolkit.py
+++ b/tests/unit_tests/test_glean_toolkit.py
@@ -15,7 +15,7 @@ class TestGleanToolkit:
         os.environ["GLEAN_API_TOKEN"] = "test-token"
         os.environ["GLEAN_ACT_AS"] = "test@example.com"
 
-        with patch("langchain_glean.retrievers.people.Glean"), patch("langchain_glean.retrievers.search.Glean"):
+        with patch("langchain_glean._api_client_mixin.Glean"):
             tk = GleanToolkit()
             tools = tk.get_tools()
 

--- a/tests/unit_tests/test_server_url.py
+++ b/tests/unit_tests/test_server_url.py
@@ -1,0 +1,88 @@
+"""Tests for server_url support in GleanAPIClientMixin."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from langchain_glean._api_client_mixin import GleanAPIClientMixin
+from langchain_glean.chat_models.chat import ChatGlean
+
+
+class TestServerUrl:
+    """Test server_url field and _build_glean_client()."""
+
+    @pytest.fixture(autouse=True)
+    def setup_method(self):
+        # Clear env vars before each test
+        for var in ["GLEAN_INSTANCE", "GLEAN_API_TOKEN", "GLEAN_ACT_AS", "GLEAN_SERVER_URL"]:
+            os.environ.pop(var, None)
+
+        os.environ["GLEAN_API_TOKEN"] = "test-token"
+
+        yield
+
+        for var in ["GLEAN_INSTANCE", "GLEAN_API_TOKEN", "GLEAN_ACT_AS", "GLEAN_SERVER_URL"]:
+            os.environ.pop(var, None)
+
+    def test_server_url_param(self):
+        """Test that server_url can be passed directly."""
+        chat = ChatGlean(server_url="https://acme-be.glean.com")
+        assert chat.server_url == "https://acme-be.glean.com"
+
+    def test_server_url_env_var(self):
+        """Test that GLEAN_SERVER_URL env var is picked up."""
+        os.environ["GLEAN_SERVER_URL"] = "https://env-be.glean.com"
+        chat = ChatGlean()
+        assert chat.server_url == "https://env-be.glean.com"
+
+    def test_server_url_takes_precedence_over_instance(self):
+        """Test that server_url takes precedence when both are set."""
+        os.environ["GLEAN_INSTANCE"] = "should-not-be-used"
+        chat = ChatGlean(server_url="https://acme-be.glean.com")
+        assert chat.server_url == "https://acme-be.glean.com"
+
+    def test_server_url_env_takes_precedence_over_instance_env(self):
+        """Test that GLEAN_SERVER_URL env var takes precedence over GLEAN_INSTANCE env var."""
+        os.environ["GLEAN_SERVER_URL"] = "https://env-be.glean.com"
+        os.environ["GLEAN_INSTANCE"] = "should-not-be-used"
+        chat = ChatGlean()
+        assert chat.server_url == "https://env-be.glean.com"
+
+    def test_instance_fallback_still_works(self):
+        """Test that instance param still works when server_url is not set."""
+        os.environ["GLEAN_INSTANCE"] = "acme"
+        chat = ChatGlean()
+        assert chat.instance == "acme"
+        assert not chat.server_url
+
+    def test_instance_param_still_works(self):
+        """Test that instance can be passed directly."""
+        chat = ChatGlean(instance="acme")
+        assert chat.instance == "acme"
+        assert not chat.server_url
+
+    def test_build_glean_client_with_server_url(self):
+        """Test _build_glean_client uses server_url when set."""
+        chat = ChatGlean(server_url="https://acme-be.glean.com")
+        with patch("langchain_glean._api_client_mixin.Glean") as mock_glean:
+            chat._build_glean_client()
+            mock_glean.assert_called_once_with(
+                server_url="https://acme-be.glean.com",
+                api_token="test-token",
+            )
+
+    def test_build_glean_client_with_instance(self):
+        """Test _build_glean_client uses instance when server_url is not set."""
+        chat = ChatGlean(instance="acme")
+        with patch("langchain_glean._api_client_mixin.Glean") as mock_glean:
+            chat._build_glean_client()
+            mock_glean.assert_called_once_with(
+                instance="acme",
+                api_token="test-token",
+            )
+
+    def test_missing_both_server_url_and_instance_raises(self):
+        """Test that omitting both server_url and instance raises ValueError."""
+        with pytest.raises(ValueError):
+            ChatGlean()


### PR DESCRIPTION
## Summary
- Added `server_url` field to `GleanAPIClientMixin` (public API surface)
- Added `_build_glean_client()` helper to route between `server_url` and `instance`
- Updated all 7 consumer files to use `_build_glean_client()` instead of direct `Glean(instance=...)` calls
- 9 new tests for `server_url` path, env var pickup, and precedence
- No breaking changes — `instance` param and `GLEAN_INSTANCE` env var continue working
- Part of the `instance → server_url` migration for DNS obfuscation support

## Test plan
- [x] All 95 unit tests pass (86 existing + 9 new)
- [x] `ChatGlean(server_url="https://acme-be.glean.com")` works
- [x] `GLEAN_SERVER_URL` env var is picked up
- [x] `server_url` takes precedence over `instance` when both set
- [x] All existing `instance` tests pass unchanged
- [ ] Smoke test with real `GLEAN_SERVER_URL`